### PR TITLE
Fix missing BaseAddress on OData HttpClient

### DIFF
--- a/IntegratoR.OData/Common/Extensions/ApplicationDependencyInjection.cs
+++ b/IntegratoR.OData/Common/Extensions/ApplicationDependencyInjection.cs
@@ -114,6 +114,7 @@ internal static class ApplicationDependencyInjection
                 .CreateClient("ODataClient");
 
             httpClient.Timeout = TimeSpan.FromSeconds(settings.Timeout);
+            httpClient.BaseAddress = new Uri(settings.Url);
 
             var options = new ODataClientOptions
             {


### PR DESCRIPTION
## Summary
- Set `HttpClient.BaseAddress` from `ODataSettings.Url` during OData client registration
- PanoramicData.OData.Client passes relative URIs to `HttpClient.SendAsync` internally, which requires `BaseAddress` to be set — without it, an `InvalidOperationException` is thrown at runtime

## Test plan
- [x] `dotnet build` passes (0 errors)
- [x] All 220 tests pass
- [ ] Verify OData calls succeed in consumer project (INW.Integration.COOR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)