### PR TITLE
Add FinancialDimensionReader to parse dimension strings

### DIFF
--- a/IntegratoR.OData.FO/Builders/FinancialDimensionReader.cs
+++ b/IntegratoR.OData.FO/Builders/FinancialDimensionReader.cs
@@ -1,0 +1,77 @@
+using FluentResults;
+using IntegratoR.Abstractions.Common.Results;
+using IntegratoR.OData.FO.Domain.Models.FinancialDimensions;
+
+namespace IntegratoR.OData.FO.Builders;
+
+/// <summary>
+/// Parses formatted financial dimension strings back into named segment values.
+/// This is the inverse of <see cref="FinancialDimensionBuilder"/> — given a dimension string
+/// like "BU01--CC002" and its <see cref="DimensionFormat"/>, it produces a dictionary mapping
+/// each segment name to its value (including empty strings for omitted segments).
+/// </summary>
+/// <example>
+/// <code>
+/// var format = new DimensionFormat
+/// {
+///     Delimiter = "-",
+///     Segments = new List&lt;string&gt; { "BusinessUnit", "Department", "CostCenter" }
+/// };
+///
+/// Result&lt;Dictionary&lt;string, string&gt;&gt; result =
+///     FinancialDimensionReader.Parse(format, "BU01--CC002");
+///
+/// // result.Value => { "BusinessUnit": "BU01", "Department": "", "CostCenter": "CC002" }
+/// </code>
+/// </example>
+public static class FinancialDimensionReader
+{
+    /// <summary>
+    /// Parses a formatted dimension string into a dictionary of segment name to value pairs.
+    /// Empty segments are preserved as empty strings to enable lossless round-tripping with
+    /// <see cref="FinancialDimensionBuilder"/>.
+    /// </summary>
+    /// <param name="format">The <see cref="DimensionFormat"/> defining the segment order and delimiter.</param>
+    /// <param name="dimensionString">The formatted dimension string to parse (e.g., "BU01--CC002").</param>
+    /// <returns>
+    /// A successful <see cref="Result{T}"/> containing a dictionary mapping segment names to their values,
+    /// or a failed result if the format is invalid, the input is empty, or the segment count does not match.
+    /// </returns>
+    public static Result<Dictionary<string, string>> Parse(DimensionFormat format, string dimensionString)
+    {
+        if (format is null || format.Segments.Count == 0)
+        {
+            return Result.Fail<Dictionary<string, string>>(new IntegrationError(
+                "DimensionReader.InvalidFormat",
+                "The dimension format is null or has no segments.",
+                ErrorType.Validation));
+        }
+
+        if (string.IsNullOrEmpty(dimensionString))
+        {
+            return Result.Fail<Dictionary<string, string>>(new IntegrationError(
+                "DimensionReader.EmptyInput",
+                "The dimension string is null or empty.",
+                ErrorType.Validation));
+        }
+
+        string[] parts = dimensionString.Split(format.Delimiter);
+
+        if (parts.Length != format.Segments.Count)
+        {
+            return Result.Fail<Dictionary<string, string>>(new IntegrationError(
+                "DimensionReader.SegmentCountMismatch",
+                $"Expected {format.Segments.Count} segments but the dimension string contains {parts.Length}.",
+                ErrorType.Validation));
+        }
+
+        Dictionary<string, string> result = new(format.Segments.Count);
+
+        for (int i = 0; i < format.Segments.Count; i++)
+        {
+            result[format.Segments[i]] = parts[i];
+        }
+
+        return Result.Ok(result);
+    }
+}

--- a/IntegratoR.OData.FO/Builders/FinancialDimensionReader.cs
+++ b/IntegratoR.OData.FO/Builders/FinancialDimensionReader.cs
@@ -39,11 +39,15 @@ public static class FinancialDimensionReader
     /// </returns>
     public static Result<Dictionary<string, string>> Parse(DimensionFormat format, string dimensionString)
     {
-        if (format is null || format.Segments.Count == 0)
+        if (format is null
+            || format.Segments is null
+            || format.Segments.Count == 0
+            || string.IsNullOrEmpty(format.Delimiter)
+            || format.Segments.Any(string.IsNullOrEmpty))
         {
             return Result.Fail<Dictionary<string, string>>(new IntegrationError(
                 "DimensionReader.InvalidFormat",
-                "The dimension format is null or has no segments.",
+                "The dimension format is null, has no segments, has a null or empty delimiter, or contains null or empty segment names.",
                 ErrorType.Validation));
         }
 

--- a/tests/IntegratoR.OData.FO.Tests/Builders/FinancialDimensionReaderTests.cs
+++ b/tests/IntegratoR.OData.FO.Tests/Builders/FinancialDimensionReaderTests.cs
@@ -180,6 +180,70 @@ public class FinancialDimensionReaderTests
     }
 
     /// <summary>
+    /// Verifies that Parse fails when the format delimiter is empty, which would otherwise
+    /// trigger string.Split's whitespace-splitting special case.
+    /// </summary>
+    [Fact]
+    public void Parse_EmptyDelimiter_ReturnsFailure()
+    {
+        // Arrange
+        var format = new DimensionFormat
+        {
+            Delimiter = string.Empty,
+            Segments = new List<string> { "BU", "Dept" }
+        };
+
+        // Act
+        var result = FinancialDimensionReader.Parse(format, "BU01-D001");
+
+        // Assert
+        result.Should().BeFailed();
+        result.Should().HaveErrorCode("DimensionReader.InvalidFormat");
+    }
+
+    /// <summary>
+    /// Verifies that Parse fails when any segment name in the format is null.
+    /// </summary>
+    [Fact]
+    public void Parse_NullSegmentName_ReturnsFailure()
+    {
+        // Arrange
+        var format = new DimensionFormat
+        {
+            Delimiter = "-",
+            Segments = new List<string> { "BU", null!, "CC" }
+        };
+
+        // Act
+        var result = FinancialDimensionReader.Parse(format, "BU01--CC002");
+
+        // Assert
+        result.Should().BeFailed();
+        result.Should().HaveErrorCode("DimensionReader.InvalidFormat");
+    }
+
+    /// <summary>
+    /// Verifies that Parse fails when any segment name in the format is an empty string.
+    /// </summary>
+    [Fact]
+    public void Parse_EmptySegmentName_ReturnsFailure()
+    {
+        // Arrange
+        var format = new DimensionFormat
+        {
+            Delimiter = "-",
+            Segments = new List<string> { "BU", string.Empty, "CC" }
+        };
+
+        // Act
+        var result = FinancialDimensionReader.Parse(format, "BU01--CC002");
+
+        // Assert
+        result.Should().BeFailed();
+        result.Should().HaveErrorCode("DimensionReader.InvalidFormat");
+    }
+
+    /// <summary>
     /// Verifies that Parse fails when the dimension string is null.
     /// </summary>
     [Fact]

--- a/tests/IntegratoR.OData.FO.Tests/Builders/FinancialDimensionReaderTests.cs
+++ b/tests/IntegratoR.OData.FO.Tests/Builders/FinancialDimensionReaderTests.cs
@@ -1,0 +1,254 @@
+using FluentAssertions;
+using IntegratoR.OData.FO.Builders;
+using IntegratoR.OData.FO.Domain.Models.FinancialDimensions;
+using IntegratoR.TestKit.Assertions;
+using Xunit;
+
+namespace IntegratoR.OData.FO.Tests.Builders;
+
+/// <summary>
+/// Tests for <see cref="FinancialDimensionReader"/> covering parsing, error handling, and round-trip with the builder.
+/// </summary>
+public class FinancialDimensionReaderTests
+{
+    /// <summary>
+    /// Verifies that Parse maps all segment values correctly when every segment is present.
+    /// </summary>
+    [Fact]
+    public void Parse_AllSegmentsPresent_ReturnsDictionary()
+    {
+        // Arrange
+        var format = new DimensionFormat
+        {
+            Delimiter = "-",
+            Segments = new List<string> { "BU", "Dept", "CC" }
+        };
+
+        // Act
+        var result = FinancialDimensionReader.Parse(format, "BU01-D001-CC002");
+
+        // Assert
+        result.Should().BeSuccessful();
+        result.Value.Should().HaveCount(3);
+        result.Value["BU"].Should().Be("BU01");
+        result.Value["Dept"].Should().Be("D001");
+        result.Value["CC"].Should().Be("CC002");
+    }
+
+    /// <summary>
+    /// Verifies that a missing middle segment is included as an empty string.
+    /// </summary>
+    [Fact]
+    public void Parse_EmptyMiddleSegment_IncludesEmptyValue()
+    {
+        // Arrange
+        var format = new DimensionFormat
+        {
+            Delimiter = "-",
+            Segments = new List<string> { "BU", "Dept", "CC" }
+        };
+
+        // Act
+        var result = FinancialDimensionReader.Parse(format, "BU01--CC002");
+
+        // Assert
+        result.Should().BeSuccessful();
+        result.Value["BU"].Should().Be("BU01");
+        result.Value["Dept"].Should().Be(string.Empty);
+        result.Value["CC"].Should().Be("CC002");
+    }
+
+    /// <summary>
+    /// Verifies that a dimension string with all empty values returns all segments mapped to empty strings.
+    /// </summary>
+    [Fact]
+    public void Parse_AllSegmentsEmpty_ReturnsAllEmptyValues()
+    {
+        // Arrange
+        var format = new DimensionFormat
+        {
+            Delimiter = "-",
+            Segments = new List<string> { "BU", "Dept", "CC" }
+        };
+
+        // Act
+        var result = FinancialDimensionReader.Parse(format, "--");
+
+        // Assert
+        result.Should().BeSuccessful();
+        result.Value.Should().HaveCount(3);
+        result.Value.Values.Should().AllBe(string.Empty);
+    }
+
+    /// <summary>
+    /// Verifies that a single-segment format parses a value without delimiters.
+    /// </summary>
+    [Fact]
+    public void Parse_SingleSegment_ReturnsOneEntry()
+    {
+        // Arrange
+        var format = new DimensionFormat
+        {
+            Delimiter = "-",
+            Segments = new List<string> { "MainAccount" }
+        };
+
+        // Act
+        var result = FinancialDimensionReader.Parse(format, "110110");
+
+        // Assert
+        result.Should().BeSuccessful();
+        result.Value.Should().HaveCount(1);
+        result.Value["MainAccount"].Should().Be("110110");
+    }
+
+    /// <summary>
+    /// Verifies that Parse fails when the dimension string has more segments than the format defines.
+    /// </summary>
+    [Fact]
+    public void Parse_MoreSegmentsThanFormat_ReturnsFailure()
+    {
+        // Arrange
+        var format = new DimensionFormat
+        {
+            Delimiter = "-",
+            Segments = new List<string> { "BU", "Dept", "CC" }
+        };
+
+        // Act
+        var result = FinancialDimensionReader.Parse(format, "BU01-D001-CC002-Extra");
+
+        // Assert
+        result.Should().BeFailed();
+        result.Should().HaveErrorCode("DimensionReader.SegmentCountMismatch");
+    }
+
+    /// <summary>
+    /// Verifies that Parse fails when the dimension string has fewer segments than the format defines.
+    /// </summary>
+    [Fact]
+    public void Parse_FewerSegmentsThanFormat_ReturnsFailure()
+    {
+        // Arrange
+        var format = new DimensionFormat
+        {
+            Delimiter = "-",
+            Segments = new List<string> { "BU", "Dept", "CC" }
+        };
+
+        // Act
+        var result = FinancialDimensionReader.Parse(format, "BU01-D001");
+
+        // Assert
+        result.Should().BeFailed();
+        result.Should().HaveErrorCode("DimensionReader.SegmentCountMismatch");
+    }
+
+    /// <summary>
+    /// Verifies that Parse fails when the format is null.
+    /// </summary>
+    [Fact]
+    public void Parse_NullFormat_ReturnsFailure()
+    {
+        // Act
+        var result = FinancialDimensionReader.Parse(null!, "BU01-D001");
+
+        // Assert
+        result.Should().BeFailed();
+        result.Should().HaveErrorCode("DimensionReader.InvalidFormat");
+    }
+
+    /// <summary>
+    /// Verifies that Parse fails when the format has no segments.
+    /// </summary>
+    [Fact]
+    public void Parse_EmptySegmentsFormat_ReturnsFailure()
+    {
+        // Arrange
+        var format = new DimensionFormat
+        {
+            Delimiter = "-",
+            Segments = new List<string>()
+        };
+
+        // Act
+        var result = FinancialDimensionReader.Parse(format, "BU01");
+
+        // Assert
+        result.Should().BeFailed();
+        result.Should().HaveErrorCode("DimensionReader.InvalidFormat");
+    }
+
+    /// <summary>
+    /// Verifies that Parse fails when the dimension string is null.
+    /// </summary>
+    [Fact]
+    public void Parse_NullDimensionString_ReturnsFailure()
+    {
+        // Arrange
+        var format = new DimensionFormat
+        {
+            Delimiter = "-",
+            Segments = new List<string> { "BU" }
+        };
+
+        // Act
+        var result = FinancialDimensionReader.Parse(format, null!);
+
+        // Assert
+        result.Should().BeFailed();
+        result.Should().HaveErrorCode("DimensionReader.EmptyInput");
+    }
+
+    /// <summary>
+    /// Verifies that Parse fails when the dimension string is empty.
+    /// </summary>
+    [Fact]
+    public void Parse_EmptyDimensionString_ReturnsFailure()
+    {
+        // Arrange
+        var format = new DimensionFormat
+        {
+            Delimiter = "-",
+            Segments = new List<string> { "BU" }
+        };
+
+        // Act
+        var result = FinancialDimensionReader.Parse(format, string.Empty);
+
+        // Assert
+        result.Should().BeFailed();
+        result.Should().HaveErrorCode("DimensionReader.EmptyInput");
+    }
+
+    /// <summary>
+    /// Verifies that parsing the output of <see cref="FinancialDimensionBuilder"/> produces
+    /// the original segment values, proving lossless round-tripping.
+    /// </summary>
+    [Fact]
+    public void Parse_RoundTrip_MatchesBuilderOutput()
+    {
+        // Arrange
+        var format = new DimensionFormat
+        {
+            Delimiter = "-",
+            Segments = new List<string> { "BU", "Dept", "CC" }
+        };
+
+        var builder = new FinancialDimensionBuilder();
+        string built = builder
+            .Initialize(format)
+            .Add("CC", "CC002")
+            .Add("BU", "BU01")
+            .Build();
+
+        // Act — parse the builder's output
+        var result = FinancialDimensionReader.Parse(format, built);
+
+        // Assert
+        result.Should().BeSuccessful();
+        result.Value["BU"].Should().Be("BU01");
+        result.Value["Dept"].Should().Be(string.Empty);
+        result.Value["CC"].Should().Be("CC002");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `FinancialDimensionReader` static class to `IntegratoR.OData.FO/Builders/` — complements the existing `FinancialDimensionBuilder` with an inverse operation
- `Parse(DimensionFormat, string)` returns `Result<Dictionary<string, string>>`, mapping each segment name to its value
- Empty segments are preserved as empty strings to enable lossless round-tripping with the builder
- Strict validation: fails with `IntegrationError` on null/empty input, invalid format, or segment count mismatch

## Design
- **Static one-shot method** — the reader has no mutable state, unlike the builder which accumulates segments
- **Dictionary return type** — simple name→value mapping that matches the builder's internal state
- **Fail fast on count mismatch** — catches data issues early rather than silently padding or truncating

## Test plan
- [x] `dotnet build` succeeds
- [x] 11 new tests in `FinancialDimensionReaderTests` all pass
  - All segments present
  - Empty middle segment
  - All segments empty
  - Single segment
  - Segment count mismatch (more / fewer)
  - Null format / empty segments format
  - Null / empty dimension string
  - Round-trip with `FinancialDimensionBuilder`
- [x] Full test suite (329 tests) passes with zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)