### PR TITLE
docs(wiki): switch sample docs to LedgerJournal smoke test

### DIFF
--- a/wiki/Azure-Functions-Host.md
+++ b/wiki/Azure-Functions-Host.md
@@ -3,28 +3,15 @@
 ```csharp
 using System.Reflection;
 using Azure.Identity;
-using FluentValidation;
-using IntegratoR.Abstractions.Common.Results;
-using IntegratoR.Application.Common.Extensions;
-using IntegratoR.OData.Common.Extensions;
-using IntegratoR.OData.FO.Common.Extensions;
-using IntegratoR.RELion.Common.Extensions;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Newtonsoft.Json;
 
-// Durable Functions state serialisation
-JsonConvert.DefaultSettings = () => new JsonSerializerSettings
-{
-    Converters = { new ResultJsonConverter(), new ResultGenericJsonConverter() }
-};
-
-var host = new HostBuilder()
+IHost host = new HostBuilder()
     .ConfigureAppConfiguration((context, config) =>
     {
-        var environment = context.HostingEnvironment;
+        IHostEnvironment environment = context.HostingEnvironment;
 
         config.SetBasePath(environment.ContentRootPath)
             .AddJsonFile($"{environment.EnvironmentName}.settings.json",
@@ -40,7 +27,7 @@ var host = new HostBuilder()
 
         if (!environment.IsDevelopment())
         {
-            var keyVaultUri = Environment.GetEnvironmentVariable("ClientSecretKeyVaultURI")
+            string keyVaultUri = Environment.GetEnvironmentVariable("ClientSecretKeyVaultURI")
                 ?? throw new ArgumentNullException("KeyVault URI is not set in environment variables.");
 
             config.AddAzureKeyVault(new Uri(keyVaultUri), new DefaultAzureCredential());
@@ -49,25 +36,24 @@ var host = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults()
     .ConfigureServices((context, services) =>
     {
-        var clientAssembly = Assembly.GetExecutingAssembly();
+        Assembly clientAssembly = Assembly.GetExecutingAssembly();
 
         services.AddApplicationInsightsTelemetryWorkerService();
         services.ConfigureFunctionsApplicationInsights();
 
-        // IntegratoR layers — order matters for pipeline behaviours
-        services.AddApplicationServices();                          // Pipeline behaviours, cache, OAuth
-        services.AddODataClient(context.Configuration);             // Generic OData client
-        services.AddODataClientFOProxy(context.Configuration);      // D365 F&O entities
-        services.AddRelionClient(context.Configuration);            // RELion client
-
-        // Host-level validators and MediatR handlers
-        services.AddValidatorsFromAssembly(clientAssembly);
-        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(clientAssembly));
+        services.AddIntegratoR(context.Configuration, integrator =>
+        {
+            integrator.AddConsumerHandlers(clientAssembly);
+        });
     })
     .Build();
 
 host.Run();
 ```
+
+`AddIntegratoR` is the single composition root for the framework. It calls `AddApplicationServices`, `AddODataClient`, and `AddODataClientFOProxy` in the correct order, binds `ODataSettings` and `FOSettings`, and automatically wires the `Result<T>` converters onto `DurableTaskWorkerOptions.DataConverter` for consumers using Durable Functions. `AddConsumerHandlers` scans the provided assembly for host-level validators and MediatR handlers.
+
+If your host also integrates RELion, call `services.AddRelionClient(context.Configuration)` after `AddIntegratoR` and register the Newtonsoft `Result<T>` converters via `JsonConvert.DefaultSettings`. See [[RELion]] for details.
 
 ## Configuration Hierarchy
 
@@ -82,13 +68,20 @@ Configuration sources load in order; later sources override earlier ones:
 
 In development, `local.settings.json` provides secrets. In deployed environments, Azure Key Vault replaces it via `DefaultAzureCredential` (Managed Identity in Azure).
 
-## Durable Functions Serialisation
+## Sample Function
 
-Durable Functions uses `Newtonsoft.Json` to serialise orchestration state. The `ResultJsonConverter` and `ResultGenericJsonConverter` ensure `Result` and `Result<T>` survive round-trip serialisation. Set `JsonConvert.DefaultSettings` **before** building the host.
+The `IntegratoR.SampleFunction` project exposes a single HTTP trigger,
+`LedgerJournalSmokeTestTrigger` (`POST /api/smoke/ledger-journal`), which exercises the
+full CRUD path against a live D365 F&O sandbox — create header, get by key, filter by
+`dataAreaId`, create balanced debit/credit lines, update, and best-effort cleanup. It uses
+the generic `CreateCommand<T>`, `UpdateCommand<T>`, `DeleteCommand<T>`, `GetByKeyQuery<T>`,
+and `GetByFilterQuery<T>` types from `IntegratoR.Abstractions` dispatched via MediatR, so
+no feature-specific handler registration is required beyond `AddIntegratoR`.
 
 ## See Also
 
 - [[Getting-Started]] — minimal setup for first-time users
-- [[Configuration]] — full settings reference for OData, F&O, and RELion
-- [[Durable-Functions]] — orchestration patterns using the host
+- [[Configuration]] — full settings reference for OData and F&O
+- [[Durable-Functions]] — orchestration patterns and `Result<T>` converter wiring
 - [[Extending-the-Pipeline]] — `AddApplicationServices()` registration details
+- [[D365-FO-Journals]] — journal commands used by the smoke test trigger

--- a/wiki/D365-FO-Journals.md
+++ b/wiki/D365-FO-Journals.md
@@ -2,26 +2,33 @@
 
 ```csharp
 // Create a journal header, build dimension strings, and add lines
-var header = new LedgerJournalHeader
+LedgerJournalHeader header = new()
 {
     DataAreaId = "USMF", JournalName = "GenJrn", Description = "Monthly accruals"
 };
-Result<LedgerJournalHeader> headerResult = await mediator.Send(
-    new CreateLedgerJournalHeaderCommand<LedgerJournalHeader>(header), cancellationToken);
+Result<LedgerJournalHeader> headerResult = await mediator
+    .Send(new CreateCommand<LedgerJournalHeader>(header), cancellationToken)
+    .ConfigureAwait(false);
 
 if (headerResult.IsFailed) return; // handle error
 string batchNumber = headerResult.Value.JournalBatchNumber!; // server-generated, e.g. "000234"
 ```
+
+The `IntegratoR.SampleFunction` project demonstrates this flow end-to-end in
+`LedgerJournalSmokeTestTrigger` (`POST /api/smoke/ledger-journal`): create header, get by
+key, filter by `dataAreaId`, create a balanced debit/credit line pair, update, and
+best-effort cleanup — all through the generic `CreateCommand<T>`, `UpdateCommand<T>`,
+`DeleteCommand<T>`, `GetByKeyQuery<T>`, and `GetByFilterQuery<T>` dispatched via MediatR.
 
 ## LedgerJournalHeader
 
 `LedgerJournalHeader : BaseEntity<string>` maps to the `LedgerJournalHeaders` OData entity set (`LedgerJournalTable` table). Composite key: `DataAreaId` + `JournalBatchNumber`.
 
 ```csharp
+using IntegratoR.Abstractions.Common.CQRS.Commands;
 using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
-using IntegratoR.OData.FO.Features.Commands.LedgerJournals.CreateLedgerJournalHeader;
 
-var header = new LedgerJournalHeader
+LedgerJournalHeader header = new()
 {
     DataAreaId = "USMF",
     JournalName = "GenJrn",
@@ -29,8 +36,9 @@ var header = new LedgerJournalHeader
     IntegrationKey = "EXT-2026-03-001" // optional idempotency key
 };
 
-Result<LedgerJournalHeader> result = await mediator.Send(
-    new CreateLedgerJournalHeaderCommand<LedgerJournalHeader>(header), cancellationToken);
+Result<LedgerJournalHeader> result = await mediator
+    .Send(new CreateCommand<LedgerJournalHeader>(header), cancellationToken)
+    .ConfigureAwait(false);
 // JournalBatchNumber excluded from POST (ODataField IgnoreOnCreate) — F&O assigns it
 ```
 
@@ -46,17 +54,18 @@ Result<LedgerJournalHeader> result = await mediator.Send(
 | `JournalTotalDebit` | `decimal` | No | -- | Server-calculated: sum of line debits (not stripped from payload, but D365 ignores client values) |
 | `JournalTotalCredit` | `decimal` | No | -- | Server-calculated: sum of line credits (not stripped from payload, but D365 ignores client values) |
 
-Batch creation uses `CreateLedgerJournalHeadersCommand<LedgerJournalHeader>(headers)` returning `Result` (non-generic — batch commands do not return created entities).
+Batch creation uses `CreateBatchCommand<LedgerJournalHeader>(headers)` returning `Result` (non-generic — batch commands do not return created entities). See [[Batch-Operations]].
 
 ## LedgerJournalLine
 
 `LedgerJournalLine : BaseEntity<string>` maps to `LedgerJournalLines` (`LedgerJournalTrans` table). Composite key: `DataAreaId` + `JournalBatchNumber` + `LineNumber`.
 
 ```csharp
-using IntegratoR.OData.FO.Features.Commands.LedgerJournals.CreateLedgerJournalLine;
+using IntegratoR.Abstractions.Common.CQRS.Commands;
+using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
 using IntegratoR.OData.FO.Domain.Enums.LedgerJournals;
 
-var debitLine = new LedgerJournalLine
+LedgerJournalLine debitLine = new()
 {
     DataAreaId = "USMF",
     JournalBatchNumber = batchNumber,
@@ -68,7 +77,7 @@ var debitLine = new LedgerJournalLine
     TransactionText = "Rent expense"          // excluded from POST payload
 };
 
-var creditLine = new LedgerJournalLine
+LedgerJournalLine creditLine = new()
 {
     DataAreaId = "USMF",
     JournalBatchNumber = batchNumber,
@@ -80,8 +89,9 @@ var creditLine = new LedgerJournalLine
     TransactionText = "Rent accrual"          // excluded from POST payload
 };
 
-Result<LedgerJournalLine> debitResult = await mediator.Send(
-    new CreateLedgerJournalLineCommand<LedgerJournalLine>(debitLine), cancellationToken);
+Result<LedgerJournalLine> debitResult = await mediator
+    .Send(new CreateCommand<LedgerJournalLine>(debitLine), cancellationToken)
+    .ConfigureAwait(false);
 // LineNumber is server-generated (IgnoreOnCreate), e.g. 1.0000
 ```
 
@@ -114,7 +124,7 @@ Most properties have `[ODataField(IgnoreOnCreate = true)]` — D365 F&O populate
 using IntegratoR.OData.FO.Builders;
 using IntegratoR.OData.FO.Domain.Models.FinancialDimensions;
 
-var format = new DimensionFormat { Delimiter = "-", Segments = ["MainAccount", "BusinessUnit", "CostCenter"] };
+DimensionFormat format = new() { Delimiter = "-", Segments = ["MainAccount", "BusinessUnit", "CostCenter"] };
 
 string account = new FinancialDimensionBuilder()
     .Initialize(format)             // Initialize(DimensionFormat) -> FinancialDimensionBuilder
@@ -137,11 +147,13 @@ Rather than hardcoding `DimensionFormat`, fetch it from F&O with GetDimensionOrd
 using IntegratoR.OData.FO.Domain.Enums.Dimensions;
 using IntegratoR.OData.FO.Features.Queries.Dimensions.GetDimensionOrder;
 
-var query = new GetDimensionOrdersQuery(
+GetDimensionOrdersQuery query = new(
     "LedgerDimension",
     DimensionHierarchyType.DataEntityLedgerDimensionFormat);
 
-Result<DimensionFormat> formatResult = await mediator.Send(query, cancellationToken);
+Result<DimensionFormat> formatResult = await mediator
+    .Send(query, cancellationToken)
+    .ConfigureAwait(false);
 // CacheKey: "GetDimensionOrdersQuery-LedgerDimension-DataEntityLedgerDimensionFormat"
 
 string accountDisplayValue = new FinancialDimensionBuilder()
@@ -163,19 +175,21 @@ string accountDisplayValue = new FinancialDimensionBuilder()
 
 ```csharp
 // 1. Fetch dimension format from F&O
-Result<DimensionFormat> format = await mediator.Send(
-    new GetDimensionOrdersQuery("LedgerDimension",
-        DimensionHierarchyType.DataEntityLedgerDimensionFormat), cancellationToken);
+Result<DimensionFormat> format = await mediator
+    .Send(new GetDimensionOrdersQuery("LedgerDimension",
+        DimensionHierarchyType.DataEntityLedgerDimensionFormat), cancellationToken)
+    .ConfigureAwait(false);
 
-var dimBuilder = new FinancialDimensionBuilder();
+FinancialDimensionBuilder dimBuilder = new();
 
 // 2. Create journal header
-var header = new LedgerJournalHeader
+LedgerJournalHeader header = new()
 {
     DataAreaId = "USMF", JournalName = "GenJrn", Description = "March accruals"
 };
-Result<LedgerJournalHeader> headerResult = await mediator.Send(
-    new CreateLedgerJournalHeaderCommand<LedgerJournalHeader>(header), cancellationToken);
+Result<LedgerJournalHeader> headerResult = await mediator
+    .Send(new CreateCommand<LedgerJournalHeader>(header), cancellationToken)
+    .ConfigureAwait(false);
 
 if (headerResult.IsFailed) return; // handle error
 string journalId = headerResult.Value.JournalBatchNumber!;
@@ -194,8 +208,8 @@ string creditAccount = dimBuilder
     .Add("BusinessUnit", "001")
     .Build(); // e.g. "200110-001--"
 
-var lines = new List<LedgerJournalLine>
-{
+List<LedgerJournalLine> lines =
+[
     new()
     {
         DataAreaId = "USMF", JournalBatchNumber = journalId,
@@ -212,10 +226,11 @@ var lines = new List<LedgerJournalLine>
         CurrencyCode = "USD", CreditAmount = 1500.00m,                         // CurrencyCode: excluded from POST payload
         TransDate = new DateTimeOffset(2026, 3, 31, 0, 0, 0, TimeSpan.Zero)   // required by C#, excluded from POST payload
     }
-};
+];
 
-Result lineResults = await mediator.Send(
-    new CreateLedgerJournalLinesCommand<LedgerJournalLine>(lines), cancellationToken);
+Result lineResults = await mediator
+    .Send(new CreateBatchCommand<LedgerJournalLine>(lines), cancellationToken)
+    .ConfigureAwait(false);
 ```
 
 ## See Also

--- a/wiki/Durable-Functions.md
+++ b/wiki/Durable-Functions.md
@@ -36,9 +36,9 @@ IntegratoR uses **two** JSON serialisers and `Result<T>` needs converters in bot
   `DistributedCacheService.SerializerOptions`. STJ converters live in
   `IntegratoR.Abstractions/Common/Results/SystemText/`.
 - **Newtonsoft.Json** — the RELion API client (`[JsonProperty]` attributes,
-  `JsonConvert.DeserializeObject`) and HTTP trigger payloads. Configured globally via
-  `JsonConvert.DefaultSettings` in `Program.cs`. Newtonsoft converters live in
-  `IntegratoR.Abstractions/Common/Results/`.
+  `JsonConvert.DeserializeObject`) and any HTTP trigger payloads that opt into Newtonsoft.
+  Configured globally via `JsonConvert.DefaultSettings` in your host's `Program.cs`.
+  Newtonsoft converters live in `IntegratoR.Abstractions/Common/Results/`.
 
 Both converter families delegate to the serialiser-agnostic `ResultJsonShape` helper for
 property names and the `IError ↔ (code, message, type)` mapping, so the JSON shape stays
@@ -49,19 +49,19 @@ in lockstep across both.
 Activity functions wrap MediatR calls, returning `Result<T>` through orchestration state:
 
 ```csharp
-public class JournalActivities
+public sealed class LedgerJournalActivityFunctions
 {
     private readonly IMediator _mediator;
 
-    public JournalActivities(IMediator mediator) => _mediator = mediator;
+    public LedgerJournalActivityFunctions(IMediator mediator) => _mediator = mediator;
 
     [Function(nameof(CreateJournalHeader))]
     public async Task<Result<LedgerJournalHeader>> CreateJournalHeader(
         [ActivityTrigger] LedgerJournalHeader header,
         CancellationToken cancellationToken)
     {
-        var command = new CreateLedgerJournalHeaderCommand<LedgerJournalHeader>(header);
-        return await _mediator.Send(command, cancellationToken);
+        CreateCommand<LedgerJournalHeader> command = new(header);
+        return await _mediator.Send(command, cancellationToken).ConfigureAwait(false);
     }
 
     [Function(nameof(CreateJournalLine))]
@@ -69,24 +69,24 @@ public class JournalActivities
         [ActivityTrigger] LedgerJournalLine line,
         CancellationToken cancellationToken)
     {
-        var command = new CreateLedgerJournalLineCommand<LedgerJournalLine>(line);
-        return await _mediator.Send(command, cancellationToken);
+        CreateCommand<LedgerJournalLine> command = new(line);
+        return await _mediator.Send(command, cancellationToken).ConfigureAwait(false);
     }
 }
 ```
 
 ## Fan-Out/Fan-In Orchestration
 
-The orchestrator creates a header, then fans out to create lines in parallel and fans in to collect results:
+An orchestrator creates a header, then fans out to create lines in parallel and fans in to collect results:
 
 ```csharp
-public class JournalOrchestrator
+public sealed class JournalOrchestrator
 {
     [Function(nameof(CreateJournalOrchestration))]
     public async Task<Result<string>> CreateJournalOrchestration(
         [OrchestrationTrigger] TaskOrchestrationContext context)
     {
-        var header = new LedgerJournalHeader
+        LedgerJournalHeader header = new()
         {
             DataAreaId = "USMF",
             JournalName = "GenJrn",
@@ -94,16 +94,18 @@ public class JournalOrchestrator
         };
 
         Result<LedgerJournalHeader> headerResult = await context.CallActivityAsync<Result<LedgerJournalHeader>>(
-            nameof(JournalActivities.CreateJournalHeader), header);
+            nameof(LedgerJournalActivityFunctions.CreateJournalHeader), header);
 
         if (headerResult.IsFailed)
+        {
             return Result.Fail<string>(headerResult.Errors); // propagate activity errors
+        }
 
         string journalBatchNumber = headerResult.Value.JournalBatchNumber!;
 
         // Fan out — create lines in parallel
-        var lines = new List<LedgerJournalLine>
-        {
+        List<LedgerJournalLine> lines =
+        [
             new()
             {
                 DataAreaId = "USMF",
@@ -124,28 +126,35 @@ public class JournalOrchestrator
                 TransDate = new DateTimeOffset(2026, 3, 31, 0, 0, 0, TimeSpan.Zero),
                 CreditAmount = 1500.00m
             }
-        };
+        ];
 
-        var lineTasks = lines.Select(line =>
+        IEnumerable<Task<Result<LedgerJournalLine>>> lineTasks = lines.Select(line =>
             context.CallActivityAsync<Result<LedgerJournalLine>>(
-                nameof(JournalActivities.CreateJournalLine), line));
+                nameof(LedgerJournalActivityFunctions.CreateJournalLine), line));
 
         // Fan in — await all, aggregate failures
         Result<LedgerJournalLine>[] lineResults = await Task.WhenAll(lineTasks);
 
-        var failures = lineResults.Where(r => r.IsFailed).ToList();
-        if (failures.Any())
+        List<Result<LedgerJournalLine>> failures = lineResults.Where(r => r.IsFailed).ToList();
+        if (failures.Count > 0)
+        {
             return Result.Fail<string>(failures.SelectMany(f => f.Errors));
+        }
 
         return Result.Ok(journalBatchNumber);
     }
 }
 ```
 
+> The example classes above (`LedgerJournalActivityFunctions`, `JournalOrchestrator`) are illustrative
+> sketches — they live in your consuming project, not in the framework. The classes you
+> define against `IMediator` and the generic `CreateCommand<T>` type are enough to get
+> `Result<T>` round-tripping through the task hub.
+
 ## HTTP Starter
 
 ```csharp
-public class JournalStarter
+public sealed class JournalStarter
 {
     [Function(nameof(StartJournalOrchestration))]
     public async Task<HttpResponseData> StartJournalOrchestration(
@@ -174,7 +183,7 @@ throw new InvalidOperationException("Something went wrong");
 
 ## See Also
 
-- [[Azure-Functions-Host]] — host setup with `ResultJsonConverter` registration
+- [[Azure-Functions-Host]] — host setup and `AddIntegratoR` composition
 - [[Error-Handling]] — `Result<T>` pattern and `IntegrationError`
 - [[D365-FO-Journals]] — journal entities used in orchestrations
 - [[Batch-Operations]] — alternative to fan-out for bulk operations

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -5,7 +5,8 @@ dotnet add package IntegratoR.Abstractions
 dotnet add package IntegratoR.Application
 dotnet add package IntegratoR.OData
 dotnet add package IntegratoR.OData.FO    # for D365 F&O
-dotnet add package IntegratoR.RELion      # for RELion API
+dotnet add package IntegratoR.Hosting     # for AddIntegratoR composition root
+dotnet add package IntegratoR.RELion      # optional — RELion API integration
 ```
 
 `IntegratoR.Abstractions` and `IntegratoR.Application` are required. The others are optional depending on your integration target. Core dependencies (FluentResults, MediatR, FluentValidation) are pulled in transitively.
@@ -36,24 +37,27 @@ See [[Configuration]] for the full property reference and authentication modes.
 ## Register Services
 
 ```csharp
-using IntegratoR.Application.Common.Extensions;
-using IntegratoR.OData.Common.Extensions;
-using IntegratoR.OData.FO.Common.Extensions;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
-var host = new HostBuilder()
+IHost host = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults()
     .ConfigureServices((context, services) =>
     {
-        services.AddApplicationServices();                          // MediatR pipeline, validators, cache, auth
-        services.AddODataClient(context.Configuration);             // OData HTTP client, Polly policies
-        services.AddODataClientFOProxy(context.Configuration);      // D365 F&O handlers
+        Assembly clientAssembly = Assembly.GetExecutingAssembly();
+
+        services.AddIntegratoR(context.Configuration, integrator =>
+        {
+            integrator.AddConsumerHandlers(clientAssembly);
+        });
     })
     .Build();
 
 host.Run();
 ```
 
-`AddApplicationServices()` must be called **first** — it registers MediatR pipeline behaviours in order: Logging -> Validation -> Caching -> Handler. See [[Azure-Functions-Host]] for a production-ready `Program.cs`.
+`AddIntegratoR` is the single composition entry point. It registers the Application layer (MediatR pipeline behaviours in order Logging -> Validation -> Caching -> Handler, cache service, OAuth authenticator), the generic OData HTTP client with Polly policies, and the D365 F&O handlers. `AddConsumerHandlers` scans the provided assembly for host-level validators and MediatR handlers. See [[Azure-Functions-Host]] for a production-ready `Program.cs`.
 
 You can also configure programmatically instead of using `appsettings.json`:
 
@@ -110,14 +114,14 @@ See [[Entities]] for `BaseEntity<TKey>`, `ODataFieldAttribute`, and custom entit
 ## Send a Command
 
 ```csharp
-var header = new LedgerJournalHeader
+LedgerJournalHeader header = new()
 {
     DataAreaId = "USMF",
     JournalName = "GenJrn",
     Description = "Monthly accruals - March 2026"
 };
 
-var command = new CreateCommand<LedgerJournalHeader>(header);
+CreateCommand<LedgerJournalHeader> command = new(header);
 Result<LedgerJournalHeader> result = await mediator.Send(command, cancellationToken);
 
 if (result.IsSuccess)
@@ -133,12 +137,12 @@ if (result.IsSuccess)
 
 ```csharp
 // By composite key
-var query = new GetByKeyQuery<LedgerJournalHeader>(["USMF", "JBN-000431"]);
+GetByKeyQuery<LedgerJournalHeader> query = new(["USMF", "JBN-000431"]);
 Result<LedgerJournalHeader> result = await mediator.Send(query, cancellationToken);
 // result.Value contains the matching entity
 
 // By filter expression
-var filter = new GetByFilterQuery<LedgerJournalHeader>(
+GetByFilterQuery<LedgerJournalHeader> filter = new(
     h => h.DataAreaId == "USMF" && h.JournalName == "GenJrn");
 Result<IEnumerable<LedgerJournalHeader>> results = await mediator.Send(filter, cancellationToken);
 // results.Value contains all matching entities
@@ -146,17 +150,24 @@ Result<IEnumerable<LedgerJournalHeader>> results = await mediator.Send(filter, c
 
 See [[Queries]] for filter syntax and return types.
 
+## Try It End-to-End
+
+The `IntegratoR.SampleFunction` project in this repo exposes a single HTTP trigger,
+`LedgerJournalSmokeTestTrigger` at `POST /api/smoke/ledger-journal`, that exercises the
+same commands and queries shown above against a live D365 F&O sandbox — create header,
+get by key, filter by `dataAreaId`, create a balanced debit/credit line pair, update the
+header, and best-effort cleanup. It's the fastest way to confirm your credentials and
+configuration are correct before building your own endpoints.
+
 ## What Just Happened
 
 The steps above assembled a working integration pipeline:
 
 1. **NuGet packages** brought in the framework and its dependencies (MediatR, FluentResults, FluentValidation, Polly).
 2. **`ODataSettings`** configured the HTTP connection and OAuth credentials for your D365 F&O environment.
-3. **`AddApplicationServices()`** registered the MediatR pipeline (Logging -> Validation -> Caching -> Handler), cache service, and OAuth authenticator.
-4. **`AddODataClient()`** registered the generic OData HTTP client with Polly retry/circuit-breaker policies.
-5. **`AddODataClientFOProxy()`** registered the D365 F&O-specific entity handlers and validators.
-6. **The entity** mapped C# properties to OData JSON fields, with `[ODataField(IgnoreOnCreate = true)]` excluding server-generated values from the POST payload.
-7. **`CreateCommand<T>`** sent the entity through the full pipeline — logging the request, validating the entity, then POSTing to D365 and returning a `Result<T>` with the server-populated fields.
+3. **`AddIntegratoR()`** registered everything in the correct order: the MediatR pipeline (Logging -> Validation -> Caching -> Handler), the cache service and OAuth authenticator, the generic OData HTTP client with Polly retry/circuit-breaker policies, and the D365 F&O-specific entity handlers and validators.
+4. **The entity** mapped C# properties to OData JSON fields, with `[ODataField(IgnoreOnCreate = true)]` excluding server-generated values from the POST payload.
+5. **`CreateCommand<T>`** sent the entity through the full pipeline — logging the request, validating the entity, then POSTing to D365 and returning a `Result<T>` with the server-populated fields.
 
 ## When Things Go Wrong
 
@@ -178,7 +189,7 @@ The host throws at startup if `Url` is null or empty. Double-check your `appsett
 **Entity validation failure:**
 
 ```csharp
-var invalid = new LedgerJournalHeader
+LedgerJournalHeader invalid = new()
 {
     DataAreaId = "USMF",
     JournalName = "",           // empty — fails NotEmpty rule


### PR DESCRIPTION
## Summary

Unit 2 of 2 for the SampleFunction legacy cleanup. This PR updates the wiki so it reflects the new minimal SampleFunction host — a single `LedgerJournalSmokeTestTrigger` HTTP trigger that exercises the generic CQRS pipeline through MediatR — and removes references to the deleted RELion-coupled Durable Functions flow.

Pair with the code-side Unit 1 PR that removes `JournalTriggers`, `JournalOrchestrators`, `JournalActivities`, `CreateRelionErrorProtocol*`, `LedgerJournalLineExtension`, `RelionBookingType`, `LedgerAccountMapping`, `TaxGroupMapping`, `ItemTaxGroupMapping`, and the `AddRelionClient` wiring from `IntegratoR.SampleFunction/Program.cs`.

## Changes

- **`wiki/Azure-Functions-Host.md`** — minimal `Program.cs` example using `AddIntegratoR` + `AddConsumerHandlers`; drop manual `AddApplicationServices`/`AddODataClient`/`AddODataClientFOProxy`/`AddRelionClient`/`AddValidatorsFromAssembly`/`AddMediatR` calls and the `JsonConvert.DefaultSettings` Newtonsoft block (not needed without RELion); add a "Sample Function" section pointing at `LedgerJournalSmokeTestTrigger` (`POST /api/smoke/ledger-journal`).
- **`wiki/Getting-Started.md`** — switch the DI wiring to `AddIntegratoR`, add `IntegratoR.Hosting` to the package list, add a "Try It End-to-End" pointer to the smoke test trigger, rewrite "What Just Happened" to match the new composition.
- **`wiki/D365-FO-Journals.md`** — replace `CreateLedgerJournalHeaderCommand<T>` / `CreateLedgerJournalLineCommand<T>` / `CreateLedgerJournalHeadersCommand<T>` / `CreateLedgerJournalLinesCommand<T>` examples with the generic `CreateCommand<T>` / `CreateBatchCommand<T>` pattern used by the smoke test trigger; add a reference to `LedgerJournalSmokeTestTrigger`.
- **`wiki/Durable-Functions.md`** — keep the generic framework content (the `Result<T>` converter wiring is still supported), but rename the illustrative `JournalActivities` example to `LedgerJournalActivityFunctions` so it does not collide with the deleted `IntegratoR.SampleFunction/Functions/JournalActivities.cs`; add a note clarifying these classes live in consumer projects.

`wiki/RELion.md` is intentionally untouched — it documents the RELion library itself, not the SampleFunction.

## Verification

- `dotnet build --configuration Release` — succeeds (0 errors, 0 warnings).
- Dead-reference grep across `wiki/` for `JournalTriggers|JournalOrchestrators|JournalActivities|CreateRelionErrorProtocolCommand|CreateRelionErrorProtocolHandler|INWRelionImportBusinessEvent|LedgerJournalLineExtension|RelionBookingType` returns zero matches.
- All four touched pages still end with a `## See Also` section.
- `git diff main -- wiki/RELion.md` is empty.

## Test plan

- [ ] Docs review: confirm the prose reads correctly when rendered on the GitHub wiki.
- [ ] After Unit 1 lands on main, confirm no wiki page references a deleted SampleFunction class or command.
- [ ] Confirm `[[Durable-Functions]]` back-links from sibling wiki pages still resolve.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>