### PR TITLE
fix(odata.fo): include CurrencyCode in LedgerJournalLine create payload

### DIFF
--- a/IntegratoR.OData.FO/Domain/Entities/LedgerJournal/LedgerJournalLine.cs
+++ b/IntegratoR.OData.FO/Domain/Entities/LedgerJournal/LedgerJournalLine.cs
@@ -79,7 +79,6 @@ public class LedgerJournalLine : BaseEntity<string>
     /// </summary>
     [Required]
     [JsonPropertyName("CurrencyCode")]
-    [ODataField(IgnoreOnCreate = true)]
     public virtual required string CurrencyCode { get; set; }
 
     /// <summary>

--- a/tests/IntegratoR.OData.FO.Tests/Features/Commands/LedgerJournals/CreateLedgerJournalLine/CreateLedgerJournalLineHandlerTests.cs
+++ b/tests/IntegratoR.OData.FO.Tests/Features/Commands/LedgerJournals/CreateLedgerJournalLine/CreateLedgerJournalLineHandlerTests.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using FluentResults;
 using IntegratoR.Abstractions.Common.Results;
 using IntegratoR.Abstractions.Interfaces.Services;
@@ -125,5 +126,38 @@ public class CreateLedgerJournalLineHandlerTests
 
         // Assert
         result.Should().BeFailed();
+    }
+
+    /// <summary>
+    /// Regression test for Fix #9: ensures <see cref="LedgerJournalLine.CurrencyCode"/> is passed through
+    /// to the service layer on create. Previously the property carried
+    /// <c>[ODataField(IgnoreOnCreate = true)]</c>, which stripped the value from the wire payload and
+    /// caused D365 F&amp;O to reject the request with "Das Feld 'Währung' muss ausgefüllt werden" because
+    /// the "Allgemein" journal name has no default currency configured.
+    /// </summary>
+    [Fact]
+    public async Task CreateLedgerJournalLine_PayloadIncludes_CurrencyCode()
+    {
+        // Arrange
+        var service = Substitute.For<IService<LedgerJournalLine>>();
+        var logger = Substitute.For<ILogger<CreateLedgerJournalLineHandler<LedgerJournalLine>>>();
+        var handler = new CreateLedgerJournalLineHandler<LedgerJournalLine>(logger, service);
+
+        LedgerJournalLine line = BuildLine();
+        line.CurrencyCode = "EUR";
+
+        LedgerJournalLine? capturedEntity = null;
+        service.AddAsync(Arg.Do<LedgerJournalLine>(e => capturedEntity = e), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(line));
+
+        var command = new CreateLedgerJournalLineCommand<LedgerJournalLine>(line);
+
+        // Act
+        Result<LedgerJournalLine> result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().BeSuccessful();
+        capturedEntity.Should().NotBeNull();
+        capturedEntity!.CurrencyCode.Should().Be("EUR");
     }
 }


### PR DESCRIPTION
## Summary

- Remove `[ODataField(IgnoreOnCreate = true)]` from `LedgerJournalLine.CurrencyCode`. The attribute was contradictory with `[Required]` on the same property and was stripping the caller-supplied currency from the OData create payload, causing D365 F&O to reject journal lines against journal names that do not default a currency.
- Add a regression test `CreateLedgerJournalLine_PayloadIncludes_CurrencyCode` that captures the entity passed to `IService<LedgerJournalLine>.AddAsync` and asserts `CurrencyCode == "EUR"` survives the handler.

## Why

Smoke-test run on 2026-04-14 against the JFI sandbox using the "Allgemein" journal name failed with:

```
Validation failed: Write validation failed for table row of type 'LedgerJournalLineEntity'.
Infolog: Warning: Das Feld "Waehrung" muss ausgefuellt werden.
```

D365 only auto-defaults `CurrencyCode` from journal-name setup, which is template-dependent. "Allgemein" in the sandbox does not configure a default, so the consumer-supplied value must reach the wire. `IgnoreOnCreate` should only apply to fields that D365 generates server-side (line numbers, voucher numbers, posting status), not to fields the consumer is required to supply.

## Scope

Production change is one attribute removal. Test change is additive. No other entity file touched.

## Entity attribute audit (documentation only, no other files changed)

Every `[ODataField(Ignore...)]` currently present in `IntegratoR.OData.FO/Domain/Entities/`:

### LedgerJournalHeader.cs

| Property | Attribute | Rationale |
|---|---|---|
| `JournalBatchNumber` | `IgnoreOnCreate` | Server-generated by number sequence configured on the Journal Name (template-driven, always assigned on create). Correct. |

### LedgerJournalLine.cs (after this PR)

| Property | Attribute | Rationale |
|---|---|---|
| `LineNumber` | `IgnoreOnCreate` | Server-generated sequence within the journal batch. Correct. |
| `AccountDisplayValue` | `IgnoreOnCreate` | **Candidate for follow-up** - also carries `[Required]`, same contradiction as CurrencyCode. Consumers must supply the account; D365 will not default it. |
| `AccountType` | `IgnoreOnCreate` | Enum (Ledger/Customer/Vendor/etc.) - questionable, consumer-driven but may default from account number parsing. Leave for now. |
| `OffsetAccountDisplayValue` | `IgnoreOnCreate` | Optional field, nullable, consumer-driven. Questionable but not blocking. |
| `OffsetAccountType` | `IgnoreOnCreate` | Same as `AccountType`. |
| `OffsetCompany` | `IgnoreOnCreate` | Intercompany marker, consumer-driven. Questionable. |
| `TransDate` | `IgnoreOnCreate` | **Candidate for follow-up** - carries `[Required]` + `required` keyword. D365 does not default the posting date; consumer must supply. |
| `TransactionText` (wire: `Text`) | `IgnoreOnCreate` | Optional descriptor. Questionable. |
| `Voucher` | `IgnoreOnCreate` | Can be auto-assigned from the journal's voucher number sequence if not supplied. Correct. |
| `DefaultDimensionDisplayValue` | `IgnoreOnCreate` | Financial dimension string, consumer-driven. Questionable. |
| `OffsetDefaultDimensionDisplayValue` | `IgnoreOnCreate` | Same. |
| `DueDate` | `IgnoreOnCreate` | **Candidate for follow-up** - carries `[Required]`. Only mandatory for customer/vendor lines, where D365 can sometimes derive it from payment terms, but the `[Required]` attribute tells a different story. |
| `DocumentDate` | `IgnoreOnCreate` | **Candidate for follow-up** - carries `[Required]`. Consumer-driven external-document date. |
| `Document` | `IgnoreOnCreate` | Optional. |
| `Invoice` | `IgnoreOnCreate` | Optional. |
| `PostingProfile` | `IgnoreOnCreate` | Can default from customer/vendor setup. Correct. |
| `PaymentMethod` | `IgnoreOnCreate` | Can default from customer/vendor setup. Correct. |
| `PaymentReference` | `IgnoreOnCreate` | Optional. |
| `ExchRate` | `IgnoreOnCreate` | **Candidate for follow-up** - carries `[Required]`. D365 normally derives from the exchange-rate table for `CurrencyCode` + `TransDate`, but `[Required]` contradicts "strip on create". |
| `SalesTaxGroup` | `IgnoreOnCreate` | Can default from account setup. |
| `ItemSalesTaxGroup` | `IgnoreOnCreate` | Can default from item setup. |
| `SalesTaxCode` | `IgnoreOnCreate` | Derived from the two groups. |
| `TaxExemptNumber` | `IgnoreOnCreate` | Optional. |
| `ReverseEntry` | `IgnoreOnCreate` | Enum flag, defaults to No. Correct. |
| `ReverseDate` | `IgnoreOnCreate` | **Candidate for follow-up** - carries `[Required]`. Only meaningful when `ReverseEntry = Yes`. `[Required]` on a value-type `DateTimeOffset` is a no-op but the intent is contradictory. |

### Follow-up recommendation

The entity has seven `[Required]` + `IgnoreOnCreate` pairings in total (one was `CurrencyCode` and is fixed in this PR). The remaining six should be re-evaluated individually - some are genuine journal-default candidates, others are not. A dedicated follow-up PR should audit each against live D365 F&O behaviour rather than guessing.

## Test plan

- [x] `dotnet build --configuration Release` - clean
- [x] `dotnet test tests/IntegratoR.OData.FO.Tests --configuration Release` - 73/73 pass (including new `CreateLedgerJournalLine_PayloadIncludes_CurrencyCode`)
- [x] `dotnet test --configuration Release` - full suite green
- [x] `dotnet format --verify-no-changes` on the two touched files - clean (pre-existing CRLF issue in `tests/IntegratoR.CodeGen.Tests/Services/EntityGeneratorTests.cs` is outside this PR's scope)
- [ ] Re-run the `LedgerJournal` smoke-test HTTP trigger against the JFI sandbox and confirm the "Waehrung" validation error no longer fires.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)