### PR TITLE
feat: FinancialDimension smoke test + dimension query fixes

### DIFF
--- a/IntegratoR.OData.FO/Domain/Entities/Dimensions/DimensionIntegrationFormat.cs
+++ b/IntegratoR.OData.FO/Domain/Entities/Dimensions/DimensionIntegrationFormat.cs
@@ -12,7 +12,7 @@ namespace IntegratoR.OData.FO.Domain.Entities.Dimensions;
 /// This entity is typically a custom or helper entity used to define how segmented dimension strings 
 /// (e.g., "618160-001-023") should be constructed or deconstructed, mapping them to the correct dimension format in D365 F&O.
 /// </summary>
-[Table("DimensionIntegrationFormat")]
+[Table("DimensionIntegrationFormats")]
 public class DimensionIntegrationFormat : BaseEntity<string>
 {
     /// <summary>

--- a/IntegratoR.OData.FO/Domain/Entities/Dimensions/DimensionParameters.cs
+++ b/IntegratoR.OData.FO/Domain/Entities/Dimensions/DimensionParameters.cs
@@ -12,15 +12,24 @@ namespace IntegratoR.OData.FO.Domain.Entities.Dimensions;
 /// ensuring consistent processing across different functions.
 /// </summary>
 [Table("DimensionParameters")]
-public class DimensionParameters : BaseEntity<string>
+public class DimensionParameters : BaseEntity<int>
 {
     /// <summary>
     /// The primary key for the parameter record, used to uniquely identify this set of dimension settings.
-    /// For example, this could be a predefined value like "Default".
+    /// In D365 F&amp;O this is an integer (likely the underlying value of an X++ enum used as a
+    /// singleton key) — verified live against the JFI sandbox 2026-04-27, which returned
+    /// <c>"Key": 0</c> as a JSON number. The original CLR declaration as <c>string</c> was wrong
+    /// and caused <c>JsonException</c> on every <c>FindAll</c> call against this entity.
     /// </summary>
+    /// <remarks>
+    /// TODO: this is almost certainly an X++ enum on the D365 side (only one row exists with
+    /// <c>Key=0</c>, the classic singleton-parameter-table pattern). Map to a dedicated CLR enum
+    /// once the X++ type name is confirmed; that would give type-safe operands in <c>$filter</c>
+    /// and prevent silent breakage if D365 adds a second key value.
+    /// </remarks>
     [Key]
     [JsonPropertyName("Key")]
-    public required string Key { get; set; }
+    public required int Key { get; set; }
 
     /// <summary>
     /// Specifies the character used to separate segments within a financial dimension string.

--- a/IntegratoR.OData.FO/Domain/Entities/Dimensions/DimensionParameters.cs
+++ b/IntegratoR.OData.FO/Domain/Entities/Dimensions/DimensionParameters.cs
@@ -21,12 +21,6 @@ public class DimensionParameters : BaseEntity<int>
     /// <c>"Key": 0</c> as a JSON number. The original CLR declaration as <c>string</c> was wrong
     /// and caused <c>JsonException</c> on every <c>FindAll</c> call against this entity.
     /// </summary>
-    /// <remarks>
-    /// TODO: this is almost certainly an X++ enum on the D365 side (only one row exists with
-    /// <c>Key=0</c>, the classic singleton-parameter-table pattern). Map to a dedicated CLR enum
-    /// once the X++ type name is confirmed; that would give type-safe operands in <c>$filter</c>
-    /// and prevent silent breakage if D365 adds a second key value.
-    /// </remarks>
     [Key]
     [JsonPropertyName("Key")]
     public required int Key { get; set; }

--- a/IntegratoR.OData.FO/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryHandler.cs
+++ b/IntegratoR.OData.FO/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryHandler.cs
@@ -3,6 +3,7 @@ using IntegratoR.Abstractions.Common.Results;
 using IntegratoR.Abstractions.Interfaces.Services;
 using IntegratoR.OData.FO.Common.Extensions;
 using IntegratoR.OData.FO.Domain.Entities.Dimensions;
+using IntegratoR.OData.FO.Domain.Enums.Dimensions;
 using IntegratoR.OData.FO.Domain.Enums.General;
 using IntegratoR.OData.FO.Domain.Models.FinancialDimensions;
 using IntegratoR.OData.Interfaces.Services;
@@ -54,8 +55,23 @@ public class GetDimensionOrdersQueryHandler : IRequestHandler<GetDimensionOrders
             return Result.Fail<DimensionFormat>(dimensionParameters.Errors);
         }
 
-        var dimensionDelimiter = dimensionParameters.Value?.FirstOrDefault()?.DimensionSegmentDelimiter;
-        var dimensionOrder = dimensionFormats.Value?.FirstOrDefault()?.FinancialDimensionFormat?.Split(dimensionDelimiter.GetCharValue()).ToList();
+        // Guard against an empty DimensionParameters response. D365 stores this as a
+        // singleton-row entity so this is unexpected in practice, but if FindAll returns an
+        // empty collection (e.g. the entity set exists but the row was never seeded) the
+        // delimiter would be null and DimensionSegmentDelimiterExtensions.GetCharValue throws
+        // ArgumentOutOfRangeException on the default arm. Failing explicitly with NotFound
+        // gives the caller an actionable diagnostic instead of an obscure exception.
+        var dimensionParametersRecord = dimensionParameters.Value?.FirstOrDefault();
+        if (dimensionParametersRecord is null)
+        {
+            return Result.Fail<DimensionFormat>(new IntegrationError(
+                "DimensionParameters.NotFound",
+                "DimensionParameters returned no records — the singleton parameter row is missing in this environment.",
+                ErrorType.NotFound));
+        }
+
+        DimensionSegmentDelimiter? dimensionDelimiter = dimensionParametersRecord.DimensionSegmentDelimiter;
+        var dimensionOrder = financialDimensionFormat?.FinancialDimensionFormat?.Split(dimensionDelimiter.GetCharValue()).ToList();
 
         var dimensionFormat = new DimensionFormat
         {

--- a/IntegratoR.OData.FO/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryHandler.cs
+++ b/IntegratoR.OData.FO/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryHandler.cs
@@ -38,10 +38,10 @@ public class GetDimensionOrdersQueryHandler : IRequestHandler<GetDimensionOrders
 
         if (dimensionFormats.IsFailed)
         {
-            return Result.Fail<DimensionFormat>(new IntegrationError(
-                $"DimensionParameters.QueryFailed",
-                $"No Data returned by the query",
-                ErrorType.Failure));
+            // Propagate the underlying errors verbatim so the consumer sees the real cause
+            // (e.g. entity set not found, authentication failure, APIM rejection) instead of
+            // a generic "No Data returned by the query" that hides the diagnostics.
+            return Result.Fail<DimensionFormat>(dimensionFormats.Errors);
         }
         var financialDimensionFormat = dimensionFormats.Value?.FirstOrDefault();
 
@@ -49,10 +49,9 @@ public class GetDimensionOrdersQueryHandler : IRequestHandler<GetDimensionOrders
 
         if (dimensionParameters.IsFailed)
         {
-            return Result.Fail<DimensionFormat>(new IntegrationError(
-                $"DimensionParameters.QueryFailed",
-                $"No Data returned by the query",
-                ErrorType.Failure));
+            // Same rationale as above: surface the real underlying error from the
+            // DimensionParameters service instead of rewriting it.
+            return Result.Fail<DimensionFormat>(dimensionParameters.Errors);
         }
 
         var dimensionDelimiter = dimensionParameters.Value?.FirstOrDefault()?.DimensionSegmentDelimiter;

--- a/IntegratoR.OData/Common/Filters/IntegratoRODataExpressionTranslator.cs
+++ b/IntegratoR.OData/Common/Filters/IntegratoRODataExpressionTranslator.cs
@@ -33,6 +33,7 @@
 
 using System.Collections;
 using System.Collections.Frozen;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -242,6 +243,22 @@ internal static class IntegratoRODataExpressionTranslator
 
     private static string ParseBinaryExpression(BinaryExpression binary, ExpressionType? parentOperator)
     {
+        // Special case: enum-property-vs-constant-literal comparison. The C# compiler
+        // constant-folds `x.EnumProp == EnumType.Member` so the right operand arrives as
+        // `ConstantExpression(<int>, Int32)` — the enum type on the right is lost. D365 F&O
+        // OData v4 strictly type-checks enum operands and rejects `EnumProp eq 1` with
+        // "incompatible types ... 'Microsoft.Dynamics.DataEntities.EnumType' and 'Edm.Int32'".
+        // Reconstruct the enum type from the LEFT operand and emit the qualified-type form.
+        // Only fires when the right side is a literal int constant; captured-variable enum
+        // values still flow through the normal FormatValue Enum arm (which also emits the
+        // qualified-type form, see FormatValue).
+        if (TryFormatEnumConstantComparison(binary, out var enumResult))
+        {
+            // No OrElse/AndAlso paren-wrapping needed: the helper only fires for equality
+            // operators (eq/ne), which cannot be the enum comparison's own NodeType.
+            return enumResult;
+        }
+
         var left = ExpressionToODataFilter(binary.Left, binary.NodeType);
         var right = ExpressionToODataFilter(binary.Right, binary.NodeType);
 
@@ -258,6 +275,135 @@ internal static class IntegratoRODataExpressionTranslator
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Detects the <c>x.EnumProp &lt;op&gt; EnumLiteral</c> expression shape (where the compiler
+    /// has constant-folded the enum literal to an underlying integer <see cref="ConstantExpression"/>)
+    /// and emits the D365 F&amp;O-compatible qualified-type filter. Returns <c>false</c> without
+    /// modification if the expression is not an enum-constant comparison — callers fall through
+    /// to the generic parsing path.
+    /// </summary>
+    private static bool TryFormatEnumConstantComparison(BinaryExpression binary, [NotNullWhen(true)] out string? result)
+    {
+        result = null;
+
+        // Restricted to equality operators: relational operators (lt/le/gt/ge) rarely make
+        // semantic sense on enums (order depends on underlying integer assignment), and the
+        // symmetric orientation below would silently invert the predicate without flipping
+        // the operator. Keeping this to eq/ne avoids both pitfalls; relational enum
+        // expressions fall through to the generic path unchanged.
+        if (binary.NodeType is not ExpressionType.Equal and not ExpressionType.NotEqual)
+        {
+            return false;
+        }
+
+        var op = binary.NodeType == ExpressionType.Equal ? "eq" : "ne";
+
+        // Left must be Convert(enumMember, Int32) or similar underlying integer type.
+        // Right must be ConstantExpression holding the constant-folded integer value.
+        if (TryGetEnumMemberPath(binary.Left, out var enumType, out var memberPath)
+            && TryGetIntegerConstant(binary.Right, out var integerValue)
+            && TryFormatQualifiedEnumLiteral(enumType!, integerValue, out var rightLiteral))
+        {
+            result = $"{memberPath} {op} {rightLiteral}";
+            return true;
+        }
+
+        // Symmetric case: EnumLiteral <op> x.EnumProp (rare but legal with eq/ne, e.g.
+        // `Status.Posted == x.Status`). Emitting literal-on-left preserves semantics for
+        // equality operators because `A eq B` ≡ `B eq A`.
+        if (TryGetEnumMemberPath(binary.Right, out enumType, out memberPath)
+            && TryGetIntegerConstant(binary.Left, out integerValue)
+            && TryFormatQualifiedEnumLiteral(enumType!, integerValue, out var leftLiteral))
+        {
+            result = $"{leftLiteral} {op} {memberPath}";
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Formats an integer value as the D365 F&amp;O qualified-type enum literal when the integer
+    /// corresponds to a defined enum member. Returns <c>false</c> for undefined values (e.g.
+    /// flag-combo values that aren't a single named member); callers can fall through to the
+    /// generic path so D365 returns its standard "incompatible types" error rather than a
+    /// malformed literal that references a non-existent enum name.
+    /// </summary>
+    private static bool TryFormatQualifiedEnumLiteral(Type enumType, long integerValue, [NotNullWhen(true)] out string? literal)
+    {
+        literal = null;
+
+        var enumValue = Enum.ToObject(enumType, integerValue);
+        if (!Enum.IsDefined(enumType, enumValue))
+        {
+            return false;
+        }
+
+        var memberName = Enum.GetName(enumType, enumValue);
+        if (string.IsNullOrEmpty(memberName))
+        {
+            return false;
+        }
+
+        literal = $"Microsoft.Dynamics.DataEntities.{enumType.Name}'{memberName}'";
+        return true;
+    }
+
+    /// <summary>
+    /// Unwraps a <c>Convert(enumMember, UnderlyingIntegerType)</c> expression and returns the
+    /// enum <see cref="Type"/> plus the OData member path of the underlying property. Returns
+    /// <c>false</c> when the expression is not an enum-to-integer convert.
+    /// </summary>
+    private static bool TryGetEnumMemberPath(Expression expression, out Type? enumType, out string? memberPath)
+    {
+        enumType = null;
+        memberPath = null;
+
+        if (expression is UnaryExpression { NodeType: ExpressionType.Convert } convert
+            && convert.Operand is MemberExpression member
+            && member.Type.IsEnum)
+        {
+            enumType = member.Type;
+            memberPath = GetMemberPath(member);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Extracts a non-null integer value from a <see cref="ConstantExpression"/> regardless of
+    /// the underlying integer type (byte/sbyte/short/ushort/int/uint/long/ulong). Returns
+    /// <c>false</c> if the expression is not a constant or the value is not a convertible integer.
+    /// </summary>
+    private static bool TryGetIntegerConstant(Expression expression, out long integerValue)
+    {
+        integerValue = 0;
+
+        if (expression is ConstantExpression constant && constant.Value is not null)
+        {
+            try
+            {
+                integerValue = Convert.ToInt64(constant.Value, CultureInfo.InvariantCulture);
+                return true;
+            }
+            catch (InvalidCastException)
+            {
+                return false;
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+            catch (OverflowException)
+            {
+                return false;
+            }
+        }
+
+        return false;
     }
 
     private static string ParseMethodCallExpression(MethodCallExpression methodCall)
@@ -432,11 +578,28 @@ internal static class IntegratoRODataExpressionTranslator
     // literals are valid regardless of the host process's CurrentCulture (e.g. a German locale
     // would otherwise emit "1,23" for a decimal, which is not a valid OData numeric literal).
     //
-    // The Enum arm is intentionally absent: C# `==` comparisons on enum properties get
-    // compiled with Convert(enum, int) on both sides, and ParseBinaryExpression strips Convert
-    // before reaching FormatValue. The emitted form is the underlying integer (e.g.
-    // `Status eq 1`), which D365 F&O OData accepts. Locked in by
-    // ToFilterString_EnumComparison_EmitsUnderlyingIntegerValue.
+    // Enum handling has two code paths depending on how the C# compiler compiles the
+    // comparison expression:
+    //
+    // 1. Constant-literal comparison (e.g. `x.Status == Status.Posted`): the compiler
+    //    constant-folds the literal side to `ConstantExpression(1, Int32)` directly — there is
+    //    no Convert wrapper on the literal to strip. The left side `x.Status` is wrapped in
+    //    Convert(enum, int) which ParseBinaryExpression strips to the MemberExpression. The
+    //    right side arrives at FormatValue as a plain int, so the int arm emits the underlying
+    //    integer form (`Status eq 1`). D365 F&O OData accepts this.
+    //
+    // 2. Captured-variable comparison (e.g. `x.Status == capturedVar`): the compiler emits a
+    //    MemberExpression on the closure field WITHOUT a Convert wrapper. EvaluateExpression
+    //    returns the Enum instance directly. Without the Enum arm below, the value would fall
+    //    through to IFormattable and emit the bare enum name as an unquoted identifier — D365
+    //    rejects that with "Could not find a property named 'EnumMemberName'". The Enum arm
+    //    emits the OData v4 qualified-type form that D365 F&O requires:
+    //    `Microsoft.Dynamics.DataEntities.EnumType'MemberName'`.
+    //    Ref: https://shootax.blogspot.com/2020/06/d365fo-odata-how-to-filter-on-enum.html
+    //
+    // Both forms are valid in D365 F&O OData — the integer form is a numeric literal, the
+    // qualified-type form is the canonical OData v4 enum literal.
+    //
     // Exposed as internal so ODataClientAdapter can reuse the same OData v4 literal formatter
     // for composite-key $filter construction (see ODataClientAdapter.FindByKeyAsync). Keeps the
     // filter/select/expand path and the composite-key bypass in lockstep on every primitive type.
@@ -445,6 +608,7 @@ internal static class IntegratoRODataExpressionTranslator
         null => "null",
         string s => $"'{s.Replace("'", "''")}'",
         bool b => b ? "true" : "false",
+        Enum e => $"Microsoft.Dynamics.DataEntities.{e.GetType().Name}'{e}'",
         byte by => by.ToString(CultureInfo.InvariantCulture),
         sbyte sb => sb.ToString(CultureInfo.InvariantCulture),
         short sh => sh.ToString(CultureInfo.InvariantCulture),

--- a/IntegratoR.OData/Common/Filters/IntegratoRODataExpressionTranslator.cs
+++ b/IntegratoR.OData/Common/Filters/IntegratoRODataExpressionTranslator.cs
@@ -252,7 +252,7 @@ internal static class IntegratoRODataExpressionTranslator
         // Only fires when the right side is a literal int constant; captured-variable enum
         // values still flow through the normal FormatValue Enum arm (which also emits the
         // qualified-type form, see FormatValue).
-        if (TryFormatEnumConstantComparison(binary, out var enumResult))
+        if (TryFormatEnumConstantComparison(binary, GetMemberPath, out var enumResult))
         {
             // No OrElse/AndAlso paren-wrapping needed: the helper only fires for equality
             // operators (eq/ne), which cannot be the enum comparison's own NodeType.
@@ -284,7 +284,7 @@ internal static class IntegratoRODataExpressionTranslator
     /// modification if the expression is not an enum-constant comparison — callers fall through
     /// to the generic parsing path.
     /// </summary>
-    private static bool TryFormatEnumConstantComparison(BinaryExpression binary, [NotNullWhen(true)] out string? result)
+    private static bool TryFormatEnumConstantComparison(BinaryExpression binary, Func<MemberExpression, string> memberPathResolver, [NotNullWhen(true)] out string? result)
     {
         result = null;
 
@@ -302,7 +302,7 @@ internal static class IntegratoRODataExpressionTranslator
 
         // Left must be Convert(enumMember, Int32) or similar underlying integer type.
         // Right must be ConstantExpression holding the constant-folded integer value.
-        if (TryGetEnumMemberPath(binary.Left, out var enumType, out var memberPath)
+        if (TryGetEnumMemberPath(binary.Left, memberPathResolver, out var enumType, out var memberPath)
             && TryGetIntegerConstant(binary.Right, out var integerValue)
             && TryFormatQualifiedEnumLiteral(enumType!, integerValue, out var rightLiteral))
         {
@@ -313,7 +313,7 @@ internal static class IntegratoRODataExpressionTranslator
         // Symmetric case: EnumLiteral <op> x.EnumProp (rare but legal with eq/ne, e.g.
         // `Status.Posted == x.Status`). Emitting literal-on-left preserves semantics for
         // equality operators because `A eq B` ≡ `B eq A`.
-        if (TryGetEnumMemberPath(binary.Right, out enumType, out memberPath)
+        if (TryGetEnumMemberPath(binary.Right, memberPathResolver, out enumType, out memberPath)
             && TryGetIntegerConstant(binary.Left, out integerValue)
             && TryFormatQualifiedEnumLiteral(enumType!, integerValue, out var leftLiteral))
         {
@@ -356,7 +356,7 @@ internal static class IntegratoRODataExpressionTranslator
     /// enum <see cref="Type"/> plus the OData member path of the underlying property. Returns
     /// <c>false</c> when the expression is not an enum-to-integer convert.
     /// </summary>
-    private static bool TryGetEnumMemberPath(Expression expression, out Type? enumType, out string? memberPath)
+    private static bool TryGetEnumMemberPath(Expression expression, Func<MemberExpression, string> memberPathResolver, out Type? enumType, out string? memberPath)
     {
         enumType = null;
         memberPath = null;
@@ -366,7 +366,7 @@ internal static class IntegratoRODataExpressionTranslator
             && member.Type.IsEnum)
         {
             enumType = member.Type;
-            memberPath = GetMemberPath(member);
+            memberPath = memberPathResolver(member);
             return true;
         }
 
@@ -578,27 +578,27 @@ internal static class IntegratoRODataExpressionTranslator
     // literals are valid regardless of the host process's CurrentCulture (e.g. a German locale
     // would otherwise emit "1,23" for a decimal, which is not a valid OData numeric literal).
     //
-    // Enum handling has two code paths depending on how the C# compiler compiles the
-    // comparison expression:
+    // Enum handling. Both shapes below converge on the qualified-type literal
+    // `Microsoft.Dynamics.DataEntities.EnumType'MemberName'` because D365 F&O OData v4 strictly
+    // type-checks enum operands and rejects the bare integer form (`Status eq 1`) with
+    // "incompatible types ... 'Microsoft.Dynamics.DataEntities.EnumType' and 'Edm.Int32'".
     //
     // 1. Constant-literal comparison (e.g. `x.Status == Status.Posted`): the compiler
-    //    constant-folds the literal side to `ConstantExpression(1, Int32)` directly — there is
-    //    no Convert wrapper on the literal to strip. The left side `x.Status` is wrapped in
-    //    Convert(enum, int) which ParseBinaryExpression strips to the MemberExpression. The
-    //    right side arrives at FormatValue as a plain int, so the int arm emits the underlying
-    //    integer form (`Status eq 1`). D365 F&O OData accepts this.
+    //    constant-folds the literal side to `ConstantExpression(1, Int32)`, so the right side
+    //    would arrive at FormatValue as a plain int and the Int32 arm above would emit the
+    //    rejected integer form. To prevent this, ParseBinaryExpression and
+    //    ParseLambdaBinaryExpression intercept the binary node first via
+    //    TryFormatEnumConstantComparison and emit the qualified literal directly — the
+    //    constant-folded int never reaches FormatValue. The Int32 arm therefore handles only
+    //    genuine integer values (e.g. captured `int` variables, integer property comparisons).
     //
     // 2. Captured-variable comparison (e.g. `x.Status == capturedVar`): the compiler emits a
     //    MemberExpression on the closure field WITHOUT a Convert wrapper. EvaluateExpression
     //    returns the Enum instance directly. Without the Enum arm below, the value would fall
     //    through to IFormattable and emit the bare enum name as an unquoted identifier — D365
     //    rejects that with "Could not find a property named 'EnumMemberName'". The Enum arm
-    //    emits the OData v4 qualified-type form that D365 F&O requires:
-    //    `Microsoft.Dynamics.DataEntities.EnumType'MemberName'`.
+    //    emits the same qualified-type literal so both shapes produce identical output.
     //    Ref: https://shootax.blogspot.com/2020/06/d365fo-odata-how-to-filter-on-enum.html
-    //
-    // Both forms are valid in D365 F&O OData — the integer form is a numeric literal, the
-    // qualified-type form is the canonical OData v4 enum literal.
     //
     // Exposed as internal so ODataClientAdapter can reuse the same OData v4 literal formatter
     // for composite-key $filter construction (see ODataClientAdapter.FindByKeyAsync). Keeps the
@@ -1000,6 +1000,18 @@ internal static class IntegratoRODataExpressionTranslator
 
     private static string ParseLambdaBinaryExpression(BinaryExpression binary, ParameterExpression lambdaParam, string odataParamName, ExpressionType? parentOperator)
     {
+        // Mirror the constant-literal enum interception from ParseBinaryExpression so the same
+        // qualified-type literal is emitted for `l => l.EnumProp == EnumType.Member` inside an
+        // Any/All lambda body. Without this, the recursive ParseLambdaBody calls below would
+        // strip the Convert(enum, int) wrapper on the member side and the int constant on the
+        // value side would emit `l/EnumProp eq 1` — which D365 F&O rejects with "incompatible
+        // types ... 'Edm.Int32'". A lambda-aware member-path resolver is supplied so the
+        // emitted member path is correctly prefixed with the lambda alias (`l/EnumProp`).
+        if (TryFormatEnumConstantComparison(binary, m => GetLambdaMemberPath(m, lambdaParam, odataParamName), out var enumResult))
+        {
+            return enumResult;
+        }
+
         var left = ParseLambdaBody(binary.Left, lambdaParam, odataParamName, binary.NodeType);
         var right = ParseLambdaBody(binary.Right, lambdaParam, odataParamName, binary.NodeType);
 

--- a/IntegratoR.SampleFunction/Domain/DTOs/SmokeTest/FinancialDimensionSmokeTestRequest.cs
+++ b/IntegratoR.SampleFunction/Domain/DTOs/SmokeTest/FinancialDimensionSmokeTestRequest.cs
@@ -1,0 +1,23 @@
+using IntegratoR.OData.FO.Domain.Enums.Dimensions;
+
+namespace IntegratoR.SampleFunction.Domain.DTOs.SmokeTest;
+
+/// <summary>
+/// Inputs for the FinancialDimensionSmokeTest HTTP trigger. Values are passed from the
+/// caller because D365 sandboxes differ — the <c>DimensionFormatName</c> and
+/// <c>HierarchyType</c> must reference a <c>DimensionIntegrationFormat</c> row that
+/// actually exists in the target environment. No company context is required because
+/// the dimension metadata entities are global (not per-<c>DataAreaId</c>).
+/// </summary>
+/// <param name="DimensionFormatName">
+/// The name of the <c>DimensionIntegrationFormat</c> configuration to look up (e.g.
+/// <c>"Sachkontodimensionen"</c>).
+/// </param>
+/// <param name="HierarchyType">
+/// The <see cref="DimensionHierarchyType"/> that combined with <paramref name="DimensionFormatName"/>
+/// uniquely identifies the format row. Typical value for ledger dimension formats:
+/// <see cref="DimensionHierarchyType.DataEntityLedgerDimensionFormat"/>.
+/// </param>
+public sealed record FinancialDimensionSmokeTestRequest(
+    string DimensionFormatName,
+    DimensionHierarchyType HierarchyType);

--- a/IntegratoR.SampleFunction/Domain/DTOs/SmokeTest/FinancialDimensionSmokeTestResponse.cs
+++ b/IntegratoR.SampleFunction/Domain/DTOs/SmokeTest/FinancialDimensionSmokeTestResponse.cs
@@ -1,0 +1,15 @@
+namespace IntegratoR.SampleFunction.Domain.DTOs.SmokeTest;
+
+/// <summary>
+/// Summary of a financial-dimension smoke test run. Exercises the
+/// <c>GetDimensionOrdersQuery</c> MediatR handler end-to-end against a live D365 F&amp;O
+/// sandbox so consumers can confirm the custom query handler, the underlying generic
+/// <c>IODataService&lt;DimensionParameters&gt;</c> and <c>IService&lt;DimensionIntegrationFormat&gt;</c>
+/// services, and the camelCase filter translator all work together on a read path that
+/// does NOT require a company context (the dimension metadata entities are global).
+/// </summary>
+public sealed record FinancialDimensionSmokeTestResponse(
+    bool Success,
+    string? Delimiter,
+    IReadOnlyList<string>? Segments,
+    IReadOnlyList<LedgerJournalSmokeTestStep> Steps);

--- a/IntegratoR.SampleFunction/Domain/DTOs/SmokeTest/FinancialDimensionSmokeTestResponse.cs
+++ b/IntegratoR.SampleFunction/Domain/DTOs/SmokeTest/FinancialDimensionSmokeTestResponse.cs
@@ -12,4 +12,4 @@ public sealed record FinancialDimensionSmokeTestResponse(
     bool Success,
     string? Delimiter,
     IReadOnlyList<string>? Segments,
-    IReadOnlyList<LedgerJournalSmokeTestStep> Steps);
+    IReadOnlyList<SmokeTestStep> Steps);

--- a/IntegratoR.SampleFunction/Domain/DTOs/SmokeTest/LedgerJournalSmokeTestResponse.cs
+++ b/IntegratoR.SampleFunction/Domain/DTOs/SmokeTest/LedgerJournalSmokeTestResponse.cs
@@ -9,16 +9,4 @@ namespace IntegratoR.SampleFunction.Domain.DTOs.SmokeTest;
 public sealed record LedgerJournalSmokeTestResponse(
     bool Success,
     string? CreatedJournalBatchNumber,
-    IReadOnlyList<LedgerJournalSmokeTestStep> Steps);
-
-/// <summary>
-/// Per-step outcome. On failure <see cref="ErrorCode"/> and <see cref="ErrorMessage"/>
-/// carry the <c>IntegrationError</c> details so the caller can diagnose without reading logs.
-/// </summary>
-public sealed record LedgerJournalSmokeTestStep(
-    string Name,
-    bool Success,
-    string? ErrorCode = null,
-    string? ErrorType = null,
-    string? ErrorMessage = null,
-    string? Details = null);
+    IReadOnlyList<SmokeTestStep> Steps);

--- a/IntegratoR.SampleFunction/Domain/DTOs/SmokeTest/SmokeTestStep.cs
+++ b/IntegratoR.SampleFunction/Domain/DTOs/SmokeTest/SmokeTestStep.cs
@@ -1,0 +1,15 @@
+namespace IntegratoR.SampleFunction.Domain.DTOs.SmokeTest;
+
+/// <summary>
+/// Per-step outcome shared across all smoke-test triggers (LedgerJournal, FinancialDimension,
+/// future entities). On failure <see cref="ErrorCode"/>, <see cref="ErrorType"/> and
+/// <see cref="ErrorMessage"/> carry the <c>IntegrationError</c> details so the caller can
+/// diagnose without reading host logs.
+/// </summary>
+public sealed record SmokeTestStep(
+    string Name,
+    bool Success,
+    string? ErrorCode = null,
+    string? ErrorType = null,
+    string? ErrorMessage = null,
+    string? Details = null);

--- a/IntegratoR.SampleFunction/Endpoints/FinancialDimensionSmokeTestTrigger.cs
+++ b/IntegratoR.SampleFunction/Endpoints/FinancialDimensionSmokeTestTrigger.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using FluentResults;
+using IntegratoR.Abstractions.Common.Results;
+using IntegratoR.OData.FO.Domain.Enums.Dimensions;
+using IntegratoR.OData.FO.Domain.Models.FinancialDimensions;
+using IntegratoR.OData.FO.Features.Queries.Dimensions.GetDimensionOrder;
+using IntegratoR.SampleFunction.Domain.DTOs.SmokeTest;
+using MediatR;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace IntegratoR.SampleFunction.Endpoints;
+
+/// <summary>
+/// Smoke test for the <c>GetDimensionOrdersQuery</c> MediatR handler. Exercises the
+/// two underlying D365 F&amp;O read paths (<c>DimensionIntegrationFormat</c> composite-key
+/// filter + <c>DimensionParameters</c> find-all) against a live sandbox so consumers can
+/// confirm the custom query handler, generic OData services, and the
+/// <c>[JsonPropertyName]</c>-aware filter translator all cooperate on a read surface that
+/// does NOT depend on a company context.
+/// </summary>
+/// <remarks>
+/// <para>
+/// POST a <see cref="FinancialDimensionSmokeTestRequest"/> body with the
+/// <c>DimensionFormatName</c> and <c>DimensionHierarchyType</c> that exist in the target
+/// sandbox. The trigger invokes <c>GetDimensionOrdersQuery</c>, unpacks the
+/// <see cref="DimensionFormat"/> result, and returns the delimiter and ordered segments
+/// it parsed out of the D365 response.
+/// </para>
+/// <para>
+/// Read-only by design: this trigger never writes to the sandbox, so it has no cleanup
+/// steps and is safe to run repeatedly without leaving orphan records.
+/// </para>
+/// </remarks>
+public sealed class FinancialDimensionSmokeTestTrigger
+{
+    private readonly IMediator _mediator;
+    private readonly ILogger<FinancialDimensionSmokeTestTrigger> _logger;
+
+    public FinancialDimensionSmokeTestTrigger(
+        IMediator mediator,
+        ILogger<FinancialDimensionSmokeTestTrigger> logger)
+    {
+        _mediator = mediator;
+        _logger = logger;
+    }
+
+    [Function("FinancialDimensionSmokeTest_HTTPTrigger")]
+    public async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "smoke/financial-dimensions")] HttpRequestData req,
+        CancellationToken cancellationToken)
+    {
+        FinancialDimensionSmokeTestRequest? input;
+        try
+        {
+            input = await req.ReadFromJsonAsync<FinancialDimensionSmokeTestRequest>(cancellationToken).ConfigureAwait(false);
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            return await WriteResponse(req, HttpStatusCode.BadRequest, new FinancialDimensionSmokeTestResponse(
+                Success: false,
+                Delimiter: null,
+                Segments: null,
+                Steps: [new LedgerJournalSmokeTestStep("ParseRequest", false, "SmokeTest.InvalidJson", ErrorType.Validation.ToString(), ex.Message)]),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        if (input is null || string.IsNullOrWhiteSpace(input.DimensionFormatName))
+        {
+            return await WriteResponse(req, HttpStatusCode.BadRequest, new FinancialDimensionSmokeTestResponse(
+                Success: false,
+                Delimiter: null,
+                Segments: null,
+                Steps: [new LedgerJournalSmokeTestStep("ParseRequest", false, "SmokeTest.MissingFields", ErrorType.Validation.ToString(), "DimensionFormatName is required.")]),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        var steps = new List<LedgerJournalSmokeTestStep>();
+
+        _logger.LogInformation(
+            "FinancialDimension smoke test starting for format '{DimensionFormatName}' of type '{HierarchyType}'.",
+            input.DimensionFormatName, input.HierarchyType);
+
+        // ---------------------------------------------------------------------------------
+        // 1. GetDimensionOrdersQuery — chains DimensionIntegrationFormat find + DimensionParameters find
+        // ---------------------------------------------------------------------------------
+        var queryResult = await _mediator
+            .Send(new GetDimensionOrdersQuery(input.DimensionFormatName, input.HierarchyType), cancellationToken)
+            .ConfigureAwait(false);
+
+        steps.Add(BuildStep("GetDimensionOrders", queryResult,
+            onSuccess: r => $"Delimiter='{r.Delimiter}', Segments=[{string.Join(", ", r.Segments)}]"));
+
+        string? delimiter = null;
+        IReadOnlyList<string>? segments = null;
+        if (queryResult.IsSuccess)
+        {
+            delimiter = queryResult.Value.Delimiter;
+            segments = queryResult.Value.Segments;
+        }
+
+        var success = steps.All(s => s.Success);
+        _logger.LogInformation(
+            "FinancialDimension smoke test finished. Success={Success}, Steps={StepCount}",
+            success, steps.Count);
+
+        return await WriteResponse(req, HttpStatusCode.OK,
+            new FinancialDimensionSmokeTestResponse(success, delimiter, segments, steps), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static LedgerJournalSmokeTestStep BuildStep<T>(
+        string name,
+        Result<T> result,
+        Func<T, string>? onSuccess = null)
+    {
+        if (result.IsSuccess)
+        {
+            return new LedgerJournalSmokeTestStep(
+                name,
+                Success: true,
+                Details: onSuccess?.Invoke(result.Value));
+        }
+
+        var error = result.GetError();
+        return new LedgerJournalSmokeTestStep(
+            name,
+            Success: false,
+            ErrorCode: error?.Code,
+            ErrorType: error?.Type.ToString(),
+            ErrorMessage: error?.Message);
+    }
+
+    private static async Task<HttpResponseData> WriteResponse(
+        HttpRequestData req,
+        HttpStatusCode status,
+        FinancialDimensionSmokeTestResponse body,
+        CancellationToken cancellationToken)
+    {
+        var response = req.CreateResponse(status);
+        await response.WriteAsJsonAsync(body, cancellationToken).ConfigureAwait(false);
+        return response;
+    }
+}

--- a/IntegratoR.SampleFunction/Endpoints/FinancialDimensionSmokeTestTrigger.cs
+++ b/IntegratoR.SampleFunction/Endpoints/FinancialDimensionSmokeTestTrigger.cs
@@ -62,7 +62,7 @@ public sealed class FinancialDimensionSmokeTestTrigger
                 Success: false,
                 Delimiter: null,
                 Segments: null,
-                Steps: [new LedgerJournalSmokeTestStep("ParseRequest", false, "SmokeTest.InvalidJson", ErrorType.Validation.ToString(), ex.Message)]),
+                Steps: [new SmokeTestStep("ParseRequest", false, "SmokeTest.InvalidJson", ErrorType.Validation.ToString(), ex.Message)]),
                 cancellationToken).ConfigureAwait(false);
         }
 
@@ -72,11 +72,11 @@ public sealed class FinancialDimensionSmokeTestTrigger
                 Success: false,
                 Delimiter: null,
                 Segments: null,
-                Steps: [new LedgerJournalSmokeTestStep("ParseRequest", false, "SmokeTest.MissingFields", ErrorType.Validation.ToString(), "DimensionFormatName is required.")]),
+                Steps: [new SmokeTestStep("ParseRequest", false, "SmokeTest.MissingFields", ErrorType.Validation.ToString(), "DimensionFormatName is required.")]),
                 cancellationToken).ConfigureAwait(false);
         }
 
-        var steps = new List<LedgerJournalSmokeTestStep>();
+        var steps = new List<SmokeTestStep>();
 
         _logger.LogInformation(
             "FinancialDimension smoke test starting for format '{DimensionFormatName}' of type '{HierarchyType}'.",
@@ -110,21 +110,21 @@ public sealed class FinancialDimensionSmokeTestTrigger
             .ConfigureAwait(false);
     }
 
-    private static LedgerJournalSmokeTestStep BuildStep<T>(
+    private static SmokeTestStep BuildStep<T>(
         string name,
         Result<T> result,
         Func<T, string>? onSuccess = null)
     {
         if (result.IsSuccess)
         {
-            return new LedgerJournalSmokeTestStep(
+            return new SmokeTestStep(
                 name,
                 Success: true,
                 Details: onSuccess?.Invoke(result.Value));
         }
 
         var error = result.GetError();
-        return new LedgerJournalSmokeTestStep(
+        return new SmokeTestStep(
             name,
             Success: false,
             ErrorCode: error?.Code,

--- a/IntegratoR.SampleFunction/Endpoints/LedgerJournalSmokeTestTrigger.cs
+++ b/IntegratoR.SampleFunction/Endpoints/LedgerJournalSmokeTestTrigger.cs
@@ -54,7 +54,7 @@ public sealed class LedgerJournalSmokeTestTrigger
             return await WriteResponse(req, HttpStatusCode.BadRequest, new LedgerJournalSmokeTestResponse(
                 Success: false,
                 CreatedJournalBatchNumber: null,
-                Steps: [new LedgerJournalSmokeTestStep("ParseRequest", false, "SmokeTest.InvalidJson", ErrorType.Validation.ToString(), ex.Message)]),
+                Steps: [new SmokeTestStep("ParseRequest", false, "SmokeTest.InvalidJson", ErrorType.Validation.ToString(), ex.Message)]),
                 cancellationToken).ConfigureAwait(false);
         }
 
@@ -63,11 +63,11 @@ public sealed class LedgerJournalSmokeTestTrigger
             return await WriteResponse(req, HttpStatusCode.BadRequest, new LedgerJournalSmokeTestResponse(
                 Success: false,
                 CreatedJournalBatchNumber: null,
-                Steps: [new LedgerJournalSmokeTestStep("ParseRequest", false, "SmokeTest.MissingFields", ErrorType.Validation.ToString(), "Company and JournalName are required.")]),
+                Steps: [new SmokeTestStep("ParseRequest", false, "SmokeTest.MissingFields", ErrorType.Validation.ToString(), "Company and JournalName are required.")]),
                 cancellationToken).ConfigureAwait(false);
         }
 
-        var steps = new List<LedgerJournalSmokeTestStep>();
+        var steps = new List<SmokeTestStep>();
         string? journalBatchNumber = null;
         decimal? debitLineNumber = null;
         decimal? creditLineNumber = null;
@@ -243,7 +243,7 @@ public sealed class LedgerJournalSmokeTestTrigger
     }
 
     private async Task BestEffortCleanup(
-        List<LedgerJournalSmokeTestStep> steps,
+        List<SmokeTestStep> steps,
         string company,
         string? journalBatchNumber,
         CancellationToken cancellationToken)
@@ -274,7 +274,7 @@ public sealed class LedgerJournalSmokeTestTrigger
         }
         else
         {
-            steps.Add(new LedgerJournalSmokeTestStep(
+            steps.Add(new SmokeTestStep(
                 "Cleanup.FilterLines",
                 false,
                 linesResult.GetError()?.Code,
@@ -299,21 +299,21 @@ public sealed class LedgerJournalSmokeTestTrigger
             onSuccess: _ => "deleted"));
     }
 
-    private static LedgerJournalSmokeTestStep BuildStep<T>(
+    private static SmokeTestStep BuildStep<T>(
         string name,
         Result<T> result,
         Func<T, string>? onSuccess = null)
     {
         if (result.IsSuccess)
         {
-            return new LedgerJournalSmokeTestStep(
+            return new SmokeTestStep(
                 name,
                 Success: true,
                 Details: onSuccess?.Invoke(result.Value));
         }
 
         var error = result.GetError();
-        return new LedgerJournalSmokeTestStep(
+        return new SmokeTestStep(
             name,
             Success: false,
             ErrorCode: error?.Code,

--- a/IntegratoR.SampleFunction/Program.cs
+++ b/IntegratoR.SampleFunction/Program.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Azure.Identity;
 using IntegratoR.Abstractions.Common.Results;
 using Microsoft.Azure.Functions.Worker;
@@ -46,6 +48,19 @@ var host = new HostBuilder()
 
         services.AddApplicationInsightsTelemetryWorkerService();
         services.ConfigureFunctionsApplicationInsights();
+
+        // Configure the Functions Worker's System.Text.Json options so HttpRequestData /
+        // HttpResponseData ReadFromJsonAsync / WriteAsJsonAsync accept string-valued enums
+        // (e.g. "HierarchyType": "DataEntityLedgerDimensionFormat"). Without this, the worker
+        // falls back to the STJ default which only accepts numeric enum values, forcing callers
+        // to look up the underlying integer. The worker's default JsonObjectSerializer reads
+        // from IOptions<JsonSerializerOptions>, so Configure<JsonSerializerOptions> mutates the
+        // live options instance the serializer already holds — no WorkerOptions.Serializer
+        // replacement required.
+        services.Configure<JsonSerializerOptions>(options =>
+        {
+            options.Converters.Add(new JsonStringEnumConverter());
+        });
 
         services.AddIntegratoR(context.Configuration, integrator =>
         {

--- a/tests/IntegratoR.OData.FO.Tests/Domain/Entities/Dimensions/DimensionEntityTests.cs
+++ b/tests/IntegratoR.OData.FO.Tests/Domain/Entities/Dimensions/DimensionEntityTests.cs
@@ -41,7 +41,7 @@ public class DimensionEntityTests
         // Arrange
         var entity = new DimensionParameters
         {
-            Key = "Default"
+            Key = 0
         };
 
         // Act
@@ -49,6 +49,6 @@ public class DimensionEntityTests
 
         // Assert
         key.Should().HaveCount(1);
-        key[0].Should().Be("Default");
+        key[0].Should().Be(0);
     }
 }

--- a/tests/IntegratoR.OData.FO.Tests/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryHandlerTests.cs
+++ b/tests/IntegratoR.OData.FO.Tests/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryHandlerTests.cs
@@ -163,6 +163,43 @@ public class GetDimensionOrdersQueryHandlerTests
     }
 
     /// <summary>
+    /// Regression for the empty-DimensionParameters guard. DimensionParameters is a
+    /// singleton-row entity in D365 so this is unexpected in practice, but if FindAll succeeds
+    /// with an empty collection the previous code would call GetCharValue() on a null delimiter
+    /// and throw ArgumentOutOfRangeException. The guard returns Result.Fail with a NotFound
+    /// IntegrationError so callers get an actionable diagnostic instead of an obscure throw.
+    /// </summary>
+    [Fact]
+    public async Task Handle_NoDimensionParameters_ReturnsNotFoundFailure()
+    {
+        // Arrange
+        var dimFormat = new DimensionIntegrationFormat
+        {
+            DimensionFormatName = "DefaultFormat",
+            DimensionFormatType = DimensionHierarchyType.DataEntityDefaultDimensionFormat,
+            FinancialDimensionFormat = "MainAccount-BU-Dept",
+            IsActive = NoYes.Yes
+        };
+        _dimFormatService.FindAsync(Arg.Any<Expression<Func<DimensionIntegrationFormat, bool>>>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<IEnumerable<DimensionIntegrationFormat>>(new[] { dimFormat }));
+
+        _dimParamsService.FindAll(Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<IEnumerable<DimensionParameters>>(Enumerable.Empty<DimensionParameters>()));
+
+        var query = new GetDimensionOrdersQuery(
+            "DefaultFormat",
+            DimensionHierarchyType.DataEntityDefaultDimensionFormat);
+
+        // Act
+        var result = await _sut.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().BeFailed();
+        result.Should().HaveErrorCode("DimensionParameters.NotFound");
+        result.Should().HaveErrorType(ErrorType.NotFound);
+    }
+
+    /// <summary>
     /// Verifies that Handle correctly parses a FinancialDimensionFormat string into individual segments.
     /// </summary>
     [Fact]

--- a/tests/IntegratoR.OData.FO.Tests/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryHandlerTests.cs
+++ b/tests/IntegratoR.OData.FO.Tests/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryHandlerTests.cs
@@ -45,7 +45,7 @@ public class GetDimensionOrdersQueryHandlerTests
         // Arrange
         var dimParams = new DimensionParameters
         {
-            Key = "Default",
+            Key = 0,
             DimensionSegmentDelimiter = DimensionSegmentDelimiter.Hyphen
         };
         _dimParamsService.FindAll(Arg.Any<CancellationToken>())
@@ -141,7 +141,7 @@ public class GetDimensionOrdersQueryHandlerTests
         // Arrange
         var dimParams = new DimensionParameters
         {
-            Key = "Default",
+            Key = 0,
             DimensionSegmentDelimiter = DimensionSegmentDelimiter.Hyphen
         };
         _dimParamsService.FindAll(Arg.Any<CancellationToken>())
@@ -171,7 +171,7 @@ public class GetDimensionOrdersQueryHandlerTests
         // Arrange
         var dimParams = new DimensionParameters
         {
-            Key = "Default",
+            Key = 0,
             DimensionSegmentDelimiter = DimensionSegmentDelimiter.Hyphen
         };
         _dimParamsService.FindAll(Arg.Any<CancellationToken>())

--- a/tests/IntegratoR.OData.Tests/Common/Filters/IntegratoRODataExpressionTranslatorTests.cs
+++ b/tests/IntegratoR.OData.Tests/Common/Filters/IntegratoRODataExpressionTranslatorTests.cs
@@ -254,20 +254,78 @@ public sealed class IntegratoRODataExpressionTranslatorTests
     }
 
     /// <summary>
-    /// Enum comparisons via <c>==</c> get compiled by C# with an implicit Convert-to-underlying-type
-    /// on both sides. The translator (matching PanoramicData) strips the Convert and emits the
-    /// integer value. D365 F&O OData accepts integer enum values in $filter, so this is correct.
-    /// The named-string form (<c>'Posted'</c>) is not currently supported by the translator —
-    /// callers should rely on the integer form shown here.
+    /// Enum comparisons against a <b>constant literal</b> are constant-folded by C# to an
+    /// underlying integer <see cref="ConstantExpression"/>, and <see cref="BinaryExpression.Left"/>
+    /// is wrapped in <c>Convert(enumMember, Int32)</c>. <c>ParseBinaryExpression</c> detects this
+    /// shape and emits the D365-compatible qualified-type literal. The previous integer form
+    /// (<c>Status eq 1</c>) was rejected by D365 F&amp;O OData with
+    /// "incompatible types ... 'Microsoft.Dynamics.DataEntities.EnumType' and 'Edm.Int32'",
+    /// confirmed by the 2026-04-16 dimension smoke test.
     /// </summary>
     [Fact]
-    public void ToFilterString_EnumComparison_EmitsUnderlyingIntegerValue()
+    public void ToFilterString_EnumComparison_ConstantLiteral_EmitsQualifiedTypeLiteral()
     {
         Expression<Func<JournalEntity, bool>> filter = x => x.Status == Status.Posted;
 
         var result = IntegratoRODataExpressionTranslator.ToFilterString(filter);
 
-        result.Should().Be("Status eq 1");
+        result.Should().Be("Status eq Microsoft.Dynamics.DataEntities.Status'Posted'");
+    }
+
+    /// <summary>
+    /// Regression for the 2026-04-15 dimension smoke test: when the enum comparison is against
+    /// a <b>captured local variable</b> (not a constant literal), the C# compiler emits a
+    /// MemberExpression on the closure field WITHOUT a Convert wrapper. The value reaches
+    /// FormatValue as an <see cref="Enum"/> instance and must be emitted in the OData v4
+    /// qualified-type form <c>Microsoft.Dynamics.DataEntities.EnumType'MemberName'</c>.
+    /// Prior to the fix the bare enum name was emitted as an unquoted identifier, causing D365
+    /// to reject the filter with "Could not find a property named 'Posted'".
+    /// </summary>
+    [Fact]
+    public void ToFilterString_EnumComparison_CapturedVariable_EmitsQualifiedTypeLiteral()
+    {
+        var capturedStatus = Status.Posted;
+        Expression<Func<JournalEntity, bool>> filter = x => x.Status == capturedStatus;
+
+        var result = IntegratoRODataExpressionTranslator.ToFilterString(filter);
+
+        result.Should().Be("Status eq Microsoft.Dynamics.DataEntities.Status'Posted'");
+    }
+
+    /// <summary>
+    /// Inequality comparison shape (<c>!=</c>) must emit the same qualified-type literal as
+    /// equality — the operator is the only thing that changes. Pins that the enum-constant
+    /// detection path in <c>ParseBinaryExpression</c> is not inadvertently restricted to
+    /// <c>ExpressionType.Equal</c>.
+    /// </summary>
+    [Fact]
+    public void ToFilterString_EnumInequality_ConstantLiteral_EmitsQualifiedTypeLiteral()
+    {
+        Expression<Func<JournalEntity, bool>> filter = x => x.Status != Status.Posted;
+
+        var result = IntegratoRODataExpressionTranslator.ToFilterString(filter);
+
+        result.Should().Be("Status ne Microsoft.Dynamics.DataEntities.Status'Posted'");
+    }
+
+    /// <summary>
+    /// Multi-predicate shape mirrors the real-world failure surface from
+    /// <c>GetDimensionOrdersQueryHandler</c>: a captured-variable enum AND a constant-literal
+    /// enum combined with <c>&amp;&amp;</c>. Both predicates must emit the qualified-type form;
+    /// before the ParseBinaryExpression fix the second predicate emitted <c>IsActive eq 1</c>
+    /// which D365 rejected.
+    /// </summary>
+    [Fact]
+    public void ToFilterString_MixedEnumPredicates_BothEmitQualifiedTypeLiteral()
+    {
+        var capturedStatus = Status.Posted;
+        Expression<Func<JournalEntity, bool>> filter = x => x.Status == capturedStatus && x.Status == Status.Draft;
+
+        var result = IntegratoRODataExpressionTranslator.ToFilterString(filter);
+
+        result.Should().Be(
+            "Status eq Microsoft.Dynamics.DataEntities.Status'Posted' and "
+            + "Status eq Microsoft.Dynamics.DataEntities.Status'Draft'");
     }
 
     [Fact]

--- a/tests/IntegratoR.OData.Tests/Common/Filters/IntegratoRODataExpressionTranslatorTests.cs
+++ b/tests/IntegratoR.OData.Tests/Common/Filters/IntegratoRODataExpressionTranslatorTests.cs
@@ -57,6 +57,8 @@ public sealed class IntegratoRODataExpressionTranslatorTests
         public string DataAreaId { get; set; } = string.Empty;
 
         public decimal Amount { get; set; }
+
+        public Status Status { get; set; }
     }
 
     private sealed class JournalEntityWithLines
@@ -483,6 +485,46 @@ public sealed class IntegratoRODataExpressionTranslatorTests
         var result = IntegratoRODataExpressionTranslator.ToFilterString(filter);
 
         result.Should().Be("Lines/any(l: (l/dataAreaId eq null or l/dataAreaId eq ''))");
+    }
+
+    /// <summary>
+    /// Regression for the enum-constant interception missing on the lambda path. Before this
+    /// fix, <c>l => l.Status == Status.Posted</c> inside an Any/All body was parsed by
+    /// ParseLambdaBinaryExpression which stripped the Convert(enum, int) wrapper on the
+    /// member side and emitted the integer form (<c>l/Status eq 1</c>) — D365 rejects this
+    /// with the same "incompatible types ... 'Edm.Int32'" error as the top-level case.
+    /// </summary>
+    [Fact]
+    public void ToFilterString_AnyLambdaWithEnumConstantLiteral_EmitsQualifiedTypeForm()
+    {
+        Expression<Func<JournalEntityWithLines, bool>> filter =
+            x => x.Lines.Any(l => l.Status == Status.Posted);
+
+        var result = IntegratoRODataExpressionTranslator.ToFilterString(filter);
+
+        result.Should().Be("Lines/any(l: l/Status eq Microsoft.Dynamics.DataEntities.Status'Posted')");
+    }
+
+    [Fact]
+    public void ToFilterString_AllLambdaWithEnumConstantLiteralInequality_EmitsQualifiedTypeForm()
+    {
+        Expression<Func<JournalEntityWithLines, bool>> filter =
+            x => x.Lines.All(l => l.Status != Status.Draft);
+
+        var result = IntegratoRODataExpressionTranslator.ToFilterString(filter);
+
+        result.Should().Be("Lines/all(l: l/Status ne Microsoft.Dynamics.DataEntities.Status'Draft')");
+    }
+
+    [Fact]
+    public void ToFilterString_AnyLambdaWithEnumLiteralCombinedPredicate_EmitsQualifiedTypeForm()
+    {
+        Expression<Func<JournalEntityWithLines, bool>> filter =
+            x => x.Lines.Any(l => l.Status == Status.Posted && l.Amount > 100);
+
+        var result = IntegratoRODataExpressionTranslator.ToFilterString(filter);
+
+        result.Should().Be("Lines/any(l: l/Status eq Microsoft.Dynamics.DataEntities.Status'Posted' and l/Amount gt 100)");
     }
 
     // -----------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a read-only HTTP smoke-test trigger that exercises `GetDimensionOrdersQuery` end-to-end against a live D365 F&O sandbox, plus the three framework fixes uncovered while making it work. Verified against the JFI sandbox on 2026-05-13 — returns 9 dimension segments for `"Sachkontodimensionen"` / `DataEntityLedgerDimensionFormat` with delimiter `'-'`.

## Commits

1. **`fix(odata.fo)`: correct Dimension entity table name and key type**
   - `DimensionIntegrationFormat` `[Table]` singular → plural — D365 entity set is `/DimensionIntegrationFormats`; singular caused 404 on every read.
   - `DimensionParameters.Key` `string` → `int` — D365 returns `"Key": 0` as JSON number (singleton-parameter-table X++ enum key); the string declaration threw `JsonException` on every `FindAll`.

2. **`feat(odata)`: translate enum constant comparisons to qualified form**
   - `IntegratoRODataExpressionTranslator` previously emitted enum operands as integer values. D365 F&O rejects integer form on the dimension entities (`DimensionFormatType`).
   - Intercepts constant-literal enum comparisons in `ParseBinaryExpression` via new `TryFormatEnumConstantComparison` helper and emits `Microsoft.Dynamics.DataEntities.OrderStatus'Open'` qualified literals.
   - Closure-captured enum operands still go through the existing `FormatValue` Enum arm.

3. **`refactor(odata.fo)`: propagate underlying errors in GetDimensionOrders**
   - Both failure branches in `GetDimensionOrdersQueryHandler` previously replaced inner errors with a generic `"No Data returned by the query"`. Now `Result.Fail<DimensionFormat>(result.Errors)` propagates the actual `IntegrationError` (code, type, message, inner exception).

4. **`feat(samplefunction)`: FinancialDimension smoke test HTTP trigger**
   - `POST /api/smoke/financial-dimensions` with `{DimensionFormatName, HierarchyType}` invokes `GetDimensionOrdersQuery` and returns the resolved delimiter + ordered segment list + per-step breakdown.
   - Read-only — no cleanup, safe to run repeatedly.
   - `Program.cs` adds `JsonStringEnumConverter` to the Functions Worker's shared `JsonSerializerOptions` so `HierarchyType` can be supplied as `"DataEntityLedgerDimensionFormat"` rather than `18`.

## End-to-end trace (JFI 2026-05-13)

```
[2026-05-13T09:26:47.303Z] GET .../fo/DimensionIntegrationFormats?* → 200 (3.2s)
[2026-05-13T09:26:50.564Z] GET .../fo/DimensionParameters           → 200 (327ms)
[2026-05-13T09:26:50.902Z] Handled GetDimensionOrdersQuery successfully in 3662ms
[2026-05-13T09:26:50.946Z] Executed FinancialDimensionSmokeTest_HTTPTrigger (Succeeded, 3821ms)
```

Response payload:
```json
{
  "Success": true,
  "Delimiter": "-",
  "Segments": ["MainAccount","A_Kostenstelle","B_Segment","C_Profitcenter","D_Projekte","E_Artikel_PSP","F_Debitor","G_Bewegungsarten","H_Partnergesellschaft"]
}
```

## Known follow-ups (deferred, not in this PR)

- `IntegratoRODataExpressionTranslator.cs:584–590` — block comment in `FormatValue` is now stale (constant-literal enum comparisons are intercepted earlier). Doc-only.
- `FinancialDimensionSmokeTestTrigger.BuildStep` swallows non-`IntegrationError` failures (returns null code/type/message). Same pattern as `LedgerJournalSmokeTestTrigger`. Add `?? result.Errors.FirstOrDefault()?.Message` fallback if non-`IntegrationError` errors need to surface.
- Composite-key write paths on dimension entities — same parked PanoramicData limitation as `LedgerJournalHeader`/`Line` (see `odata-composite-key-limitation` notes).

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 519 passed, 3 skipped, 0 failed
- [x] Live POST against JFI sandbox returns 9 segments with delimiter `-`
- [x] correctness-reviewer run — 0 critical, 0 major runtime bugs (1 stale-comment follow-up listed above)
- [ ] Reviewer to confirm enum qualified-name format matches what JFI accepts for any enum beyond `DimensionFormatType`

🤖 Generated with [Claude Code](https://claude.com/claude-code)