### PR TITLE
test: validate claude-review posting (do not merge)

### DIFF
--- a/REVIEW_SMOKE_TEST.md
+++ b/REVIEW_SMOKE_TEST.md
@@ -1,0 +1,5 @@
+# claude-review smoke test
+
+Temporary file to validate that the redesigned `claude-review` GitHub Action
+posts a review on a normal (non-workflow) PR. This PR is **not** meant to be
+merged — it will be closed once the reviewer's behaviour is confirmed.


### PR DESCRIPTION
Smoke test for the redesigned `claude-review` action (PR #113). A trivial non-workflow change so the action actually runs (workflow-changing PRs are skipped by GitHub). **Success = a review is posted below.** Will be closed, not merged.