### PR TITLE
fix(hosting): close generic CRUD/query handlers for consumer entities

### DIFF
--- a/IntegratoR.Hosting/Extensions/ServiceCollectionExtensions.cs
+++ b/IntegratoR.Hosting/Extensions/ServiceCollectionExtensions.cs
@@ -61,9 +61,10 @@ public static class IntegratoRServiceCollectionExtensions
         // 3b. Cross-assembly generic handler closing.
         // MediatR v12 only closes open generics against types in the SAME scanned assembly,
         // so the layer-local AddMediatR calls in AddApplicationServices() and AddODataClientFOProxy()
-        // never see the open CreateCommandHandler<T> and the F&O entity types together. This call
-        // scans both assemblies in one pass so the closed IRequestHandler<CreateCommand<T>, ...>
-        // registrations are emitted for every F&O entity.
+        // never see the open CreateCommandHandler<T> and the entity types together. This single
+        // combined scan emits the closed IRequestHandler<CreateCommand<T>, ...> registrations for
+        // every F&O entity AND every consumer-supplied entity (a subclass of an F&O entity or a new
+        // BaseEntity<TKey>), so mediator.Send(new CreateCommand<ConsumerEntity>(...)) resolves.
         services.AddMediatR(cfg =>
         {
             cfg.RegisterGenericHandlers = true;
@@ -71,6 +72,14 @@ public static class IntegratoRServiceCollectionExtensions
                 typeof(IntegratoR.Application.Features.Common.Commands.CreateCommandHandler<>).Assembly);
             cfg.RegisterServicesFromAssembly(
                 typeof(IntegratoR.OData.FO.Domain.Entities.LedgerJournal.LedgerJournalHeader).Assembly);
+
+            // Fold consumer assemblies into the SAME RegisterGenericHandlers pass so the framework's
+            // generic CRUD/query handlers are also closed over consumer entity types. Without this,
+            // a consumer's extended/custom entity would have no IRequestHandler<CreateCommand<T>, ...>.
+            foreach (Assembly assembly in builder.ConsumerAssemblies)
+            {
+                cfg.RegisterServicesFromAssembly(assembly);
+            }
         });
 
         // 4. Durable Functions Result<T> support — register the System.Text.Json Result
@@ -96,10 +105,12 @@ public static class IntegratoRServiceCollectionExtensions
             services.PostConfigure(builder.FOPostConfigure);
         }
 
-        // 6. Register consumer assemblies for MediatR + FluentValidation
+        // 6. Register consumer FluentValidation validators. Consumer MediatR handlers — including
+        //    the closed generic CRUD/query handlers for consumer entities — are already registered
+        //    by the combined RegisterGenericHandlers scan in step 3b, so they must NOT be scanned
+        //    again here (a second AddMediatR pass would emit duplicate handler registrations).
         foreach (Assembly assembly in builder.ConsumerAssemblies)
         {
-            services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(assembly));
             services.AddValidatorsFromAssembly(assembly);
         }
 

--- a/IntegratoR.Hosting/IntegratoRBuilder.cs
+++ b/IntegratoR.Hosting/IntegratoRBuilder.cs
@@ -14,7 +14,10 @@ public sealed class IntegratoRBuilder
     internal Action<FOSettings>? FOPostConfigure { get; private set; }
 
     /// <summary>
-    /// Registers MediatR handlers and FluentValidation validators from the specified consumer assemblies.
+    /// Registers the specified consumer assemblies' FluentValidation validators and folds them into
+    /// <c>AddIntegratoR</c>'s combined <c>RegisterGenericHandlers</c> MediatR scan, so the framework's
+    /// generic CRUD/query handlers close over the entity types declared in those assemblies — including
+    /// subclasses of framework entities.
     /// </summary>
     public IntegratoRBuilder AddConsumerHandlers(params Assembly[] assemblies)
     {

--- a/tests/IntegratoR.Hosting.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/tests/IntegratoR.Hosting.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -5,6 +5,7 @@ using FluentValidation;
 using IntegratoR.Abstractions.Common.CQRS.Commands;
 using IntegratoR.Abstractions.Common.CQRS.Queries;
 using IntegratoR.Abstractions.Common.Results;
+using IntegratoR.Abstractions.Domain.Entities;
 using IntegratoR.Abstractions.Interfaces.Authentication;
 using IntegratoR.Abstractions.Interfaces.Services;
 using IntegratoR.OData.Domain.Settings;
@@ -414,6 +415,158 @@ public class ServiceCollectionExtensionsTests
             await service.Received(1).FindAsync(Arg.Any<Expression<Func<LedgerJournalHeader, bool>>?>(), Arg.Any<CancellationToken>());
         }
     }
+
+    // Regression tests — consumer entity handler resolution
+    // These tests fail before the fix with:
+    //   "No service for type 'IRequestHandler<CreateCommand<ConsumerExtendedEntity>, Result<ConsumerExtendedEntity>>'"
+    // The fix is the combined-assembly MediatR scan in step 3b of AddIntegratoR that folds
+    // builder.ConsumerAssemblies into the RegisterGenericHandlers pass.
+    private static (ServiceProvider Provider, IService<ConsumerExtendedEntity> Service) BuildProviderWithSubstitutedConsumerService()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        IConfiguration configuration = CreateMinimalConfiguration();
+        services.AddIntegratoR(configuration, integrator =>
+            integrator.AddConsumerHandlers(typeof(ConsumerExtendedEntity).Assembly));
+        IService<ConsumerExtendedEntity> substitute = Substitute.For<IService<ConsumerExtendedEntity>>();
+        services.AddScoped(_ => substitute);
+        return (services.BuildServiceProvider(), substitute);
+    }
+
+    private static ConsumerExtendedEntity CreateConsumerEntity() => new()
+    {
+        Id = "C1",
+        Name = "consumer"
+    };
+
+    [Fact]
+    public async Task AddIntegratoR_ResolvesGenericCreateCommandHandler_ForConsumerEntity()
+    {
+        // Arrange
+        (ServiceProvider provider, IService<ConsumerExtendedEntity> service) = BuildProviderWithSubstitutedConsumerService();
+        await using (provider)
+        {
+            ConsumerExtendedEntity entity = CreateConsumerEntity();
+            service.AddAsync(entity, Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(Result.Ok(entity)));
+
+            using IServiceScope scope = provider.CreateScope();
+            IMediator mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            // Act
+            Result<ConsumerExtendedEntity> result =
+                await mediator.Send(new CreateCommand<ConsumerExtendedEntity>(entity), TestContext.Current.CancellationToken);
+
+            // Assert
+            result.Should().BeSuccessful();
+            result.Value.Should().BeSameAs(entity);
+            await service.Received(1).AddAsync(entity, Arg.Any<CancellationToken>());
+        }
+    }
+
+    [Fact]
+    public async Task AddIntegratoR_ResolvesGenericUpdateCommandHandler_ForConsumerEntity()
+    {
+        // Arrange
+        (ServiceProvider provider, IService<ConsumerExtendedEntity> service) = BuildProviderWithSubstitutedConsumerService();
+        await using (provider)
+        {
+            ConsumerExtendedEntity entity = CreateConsumerEntity();
+            service.UpdateAsync(entity, Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(Result.Ok(entity)));
+
+            using IServiceScope scope = provider.CreateScope();
+            IMediator mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            // Act
+            Result<ConsumerExtendedEntity> result =
+                await mediator.Send(new UpdateCommand<ConsumerExtendedEntity>(entity), TestContext.Current.CancellationToken);
+
+            // Assert
+            result.Should().BeSuccessful();
+            result.Value.Should().BeSameAs(entity);
+            await service.Received(1).UpdateAsync(entity, Arg.Any<CancellationToken>());
+        }
+    }
+
+    [Fact]
+    public async Task AddIntegratoR_ResolvesGenericDeleteCommandHandler_ForConsumerEntity()
+    {
+        // Arrange
+        (ServiceProvider provider, IService<ConsumerExtendedEntity> service) = BuildProviderWithSubstitutedConsumerService();
+        await using (provider)
+        {
+            ConsumerExtendedEntity entity = CreateConsumerEntity();
+            service.DeleteAsync(entity, Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(Result.Ok()));
+
+            using IServiceScope scope = provider.CreateScope();
+            IMediator mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            // Act
+            Result<ConsumerExtendedEntity> result =
+                await mediator.Send(new DeleteCommand<ConsumerExtendedEntity>(entity), TestContext.Current.CancellationToken);
+
+            // Assert
+            result.Should().BeSuccessful();
+            result.Value.Should().BeSameAs(entity);
+            await service.Received(1).DeleteAsync(entity, Arg.Any<CancellationToken>());
+        }
+    }
+
+    [Fact]
+    public async Task AddIntegratoR_ResolvesGenericGetByKeyQueryHandler_ForConsumerEntity()
+    {
+        // Arrange
+        (ServiceProvider provider, IService<ConsumerExtendedEntity> service) = BuildProviderWithSubstitutedConsumerService();
+        await using (provider)
+        {
+            ConsumerExtendedEntity entity = CreateConsumerEntity();
+            object[] key = ["C1"];
+            service.GetByKeyAsync(key, Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(Result.Ok(entity)));
+
+            using IServiceScope scope = provider.CreateScope();
+            IMediator mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            // Act
+            Result<ConsumerExtendedEntity> result =
+                await mediator.Send(new GetByKeyQuery<ConsumerExtendedEntity>(key), TestContext.Current.CancellationToken);
+
+            // Assert
+            result.Should().BeSuccessful();
+            result.Value.Should().BeSameAs(entity);
+            await service.Received(1).GetByKeyAsync(key, Arg.Any<CancellationToken>());
+        }
+    }
+
+    [Fact]
+    public async Task AddIntegratoR_ResolvesGenericGetByFilterQueryHandler_ForConsumerEntity()
+    {
+        // Arrange
+        (ServiceProvider provider, IService<ConsumerExtendedEntity> service) = BuildProviderWithSubstitutedConsumerService();
+        await using (provider)
+        {
+            ConsumerExtendedEntity entity = CreateConsumerEntity();
+            IEnumerable<ConsumerExtendedEntity> entities = [entity];
+            service.FindAsync(Arg.Any<Expression<Func<ConsumerExtendedEntity, bool>>?>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(Result.Ok(entities)));
+
+            using IServiceScope scope = provider.CreateScope();
+            IMediator mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            Expression<Func<ConsumerExtendedEntity, bool>> filter = e => e.Id == "C1";
+
+            // Act
+            Result<IEnumerable<ConsumerExtendedEntity>> result =
+                await mediator.Send(new GetByFilterQuery<ConsumerExtendedEntity>(filter), TestContext.Current.CancellationToken);
+
+            // Assert
+            result.Should().BeSuccessful();
+            result.Value.Should().ContainSingle().Which.Should().BeSameAs(entity);
+            await service.Received(1).FindAsync(Arg.Any<Expression<Func<ConsumerExtendedEntity, bool>>?>(), Arg.Any<CancellationToken>());
+        }
+    }
 }
 
 /// <summary>
@@ -433,4 +586,16 @@ public class DummyModelValidator : AbstractValidator<DummyModel>
     {
         RuleFor(x => x.Name).NotEmpty();
     }
+}
+
+/// <summary>
+/// Represents a consumer-defined entity living outside the framework assemblies.
+/// Used to verify that <c>AddIntegratoR</c> closes the framework's generic CRUD/query
+/// MediatR handlers over entity types supplied via <c>builder.AddConsumerHandlers(assembly)</c>.
+/// </summary>
+public class ConsumerExtendedEntity : BaseEntity<string>
+{
+    public required string Id { get; set; }
+    public string? Name { get; set; }
+    public override object[] GetCompositeKey() => [Id];
 }

--- a/wiki/Add-Validation.md
+++ b/wiki/Add-Validation.md
@@ -49,7 +49,7 @@ integrator.AddConsumerHandlers(
     typeof(SomeExternalValidator).Assembly);
 ```
 
-Internally `AddConsumerHandlers` registers each assembly via `services.AddValidatorsFromAssembly(...)` and `services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(...))`.
+Internally, `AddIntegratoR` registers every assembly passed to `AddConsumerHandlers` via `services.AddValidatorsFromAssembly(...)` for its validators, and folds it into the combined `RegisterGenericHandlers = true` MediatR scan so its handlers — including the closed generic CRUD/query handlers for its entities — register in the same pass as the framework's own.
 
 ## How Validation Fits Into the Pipeline
 

--- a/wiki/Define-Entities.md
+++ b/wiki/Define-Entities.md
@@ -212,27 +212,14 @@ Three rules make this work:
 
 ### Register the Extended Entity with MediatR
 
-Subclassing alone does **not** make `mediator.Send(new CreateCommand<MyLedgerJournalLine>(...))` work. MediatR closes the framework's generic handlers only against entity types in the same scan that sets `RegisterGenericHandlers = true`, and `AddConsumerHandlers(...)` does not do this. Add a combined scan in the composition root, after `AddIntegratoR`:
+Subclassing alone does **not** make `mediator.Send(new CreateCommand<MyLedgerJournalLine>(...))` work — the framework's generic handlers must be closed over your entity type. Hand the assembly that holds your extended entities to `AddConsumerHandlers(...)`; `AddIntegratoR` folds it into the same `RegisterGenericHandlers = true` scan it uses for the framework's own entities:
 
 ```csharp
-services.AddMediatR(cfg =>
-{
-    cfg.RegisterGenericHandlers = true;
-
-    // open generic handlers — Application layer
-    cfg.RegisterServicesFromAssembly(
-        typeof(IntegratoR.Application.Features.Common.Commands.CreateCommandHandler<>).Assembly);
-
-    // F&O open handlers (CreateLedgerJournalHeaderHandler<TEntity>, …)
-    cfg.RegisterServicesFromAssembly(
-        typeof(IntegratoR.OData.FO.Domain.Entities.LedgerJournal.LedgerJournalHeader).Assembly);
-
-    // the assembly holding your extended entities
-    cfg.RegisterServicesFromAssembly(typeof(MyLedgerJournalLine).Assembly);
-});
+services.AddIntegratoR(configuration, integrator =>
+    integrator.AddConsumerHandlers(typeof(MyLedgerJournalLine).Assembly));
 ```
 
-The service layer (`IService<MyLedgerJournalLine>`) needs no extra wiring — it is registered as an open generic and closes against any type. See [Known Limitations](Known-Limitations#consumer-entities-need-manual-generic-handler-registration) and [Troubleshoot Common Issues](Troubleshoot-Common-Issues#extending-the-framework).
+That single call closes the full generic surface — `CreateCommand<T>`, `UpdateCommand<T>`, `DeleteCommand<T>`, `GetByKeyQuery<T>`, `GetByFilterQuery<T>` — over `MyLedgerJournalLine`, and also registers its FluentValidation validators. The service layer (`IService<MyLedgerJournalLine>`) needs no extra wiring — it is an open-generic registration that closes against any type. See [Troubleshoot Common Issues](Troubleshoot-Common-Issues#extending-the-framework).
 
 ## See Also
 

--- a/wiki/Known-Limitations.md
+++ b/wiki/Known-Limitations.md
@@ -70,16 +70,6 @@ This page lists known constraints in the framework and the planned resolutions. 
 
 **Workaround status:** add coverage on demand. The translator is intentionally narrow — favouring predictable D365-compatible output over comprehensive LINQ coverage.
 
-## Consumer Entities Need Manual Generic-Handler Registration
-
-**What:** `IntegratoRBuilder.AddConsumerHandlers(...)` registers a consumer assembly's explicitly-written handlers and validators, but it does **not** close the framework's open generic CQRS handlers (`CreateCommand<T>`, `UpdateCommand<T>`, `GetByKeyQuery<T>`, the F&O `CreateLedgerJournalHeaderCommand<TEntity>` family, …) against entity types declared in the consumer assembly — including subclasses of framework entities.
-
-**Symptoms:** `mediator.Send(new CreateCommand<MyEntity>(...))` throws `InvalidOperationException: No service for type 'MediatR.IRequestHandler`2[...]' has been registered`. The service layer (`IService<MyEntity>`) resolves fine — it is an open-generic DI registration; only the MediatR handler closing is missing.
-
-**Why:** MediatR v12 closes an open generic handler only against entity types found in the same assembly scan that sets `RegisterGenericHandlers = true`. `AddIntegratoR` performs a combined Application + F&O scan for the framework's own entities, but the consumer-assembly scan in `AddConsumerHandlers` uses a plain `RegisterServicesFromAssembly` without that flag and without re-including the handler assemblies.
-
-**Workaround status:** documented workaround — add a combined `AddMediatR` scan in the composition root (see [Troubleshoot Common Issues](Troubleshoot-Common-Issues#extending-the-framework)). The planned fix folds consumer assemblies into the combined `RegisterGenericHandlers = true` scan inside `AddConsumerHandlers` so extended entities get closed handlers for free. On the backlog.
-
 ## Where to Track Progress
 
 The framework's backlog, tracked internally by maintainers, consolidates these items and tracks which has an active design and which is still scoped. Items shipping in a given release are noted in [Release Notes and Versioning](Release-Notes-and-Versioning) with the relevant PR link.

--- a/wiki/Troubleshoot-Common-Issues.md
+++ b/wiki/Troubleshoot-Common-Issues.md
@@ -124,31 +124,18 @@ Same composite-key write-path limitation surfaced via the suppressed-404 observa
 
 ### `InvalidOperationException: No service for type 'MediatR.IRequestHandler`2[...]' has been registered`
 
-`mediator.Send(...)` was called with a command or query closed over a **custom or extended entity** (for example a subclass of `LedgerJournalLine`), but no closed handler was registered for it.
+`mediator.Send(...)` was called with a command or query closed over a **custom or extended entity** (for example a subclass of `LedgerJournalLine`) whose assembly was never handed to `AddConsumerHandlers(...)`.
 
-**Why:** MediatR v12 only closes the framework's open generic handlers (`CreateCommandHandler<T>`, the F&O `CreateLedgerJournalHeaderHandler<TEntity>` family, …) against entity types found in the **same assembly scan** that sets `RegisterGenericHandlers = true`. `AddIntegratoR` does this for the framework's own F&O entities, but `AddConsumerHandlers(...)` scans the consumer assembly with a plain registration — it does **not** close the generic handlers against consumer entity types. See [Known Limitations](Known-Limitations#consumer-entities-need-manual-generic-handler-registration).
+**Why:** the framework closes its generic CQRS handlers over an entity type only when that type's assembly is part of the combined `RegisterGenericHandlers = true` scan. `AddIntegratoR` scans the Application + F&O assemblies **plus every assembly you pass to `AddConsumerHandlers(...)`**. If your entity lives in an assembly you never registered, no closed handler is emitted for it.
 
-**Resolution:** in the composition root, after `AddIntegratoR`, add a combined scan that includes the handler assemblies **and** the consumer assembly together:
+**Resolution:** register the assembly that holds your extended entity — nothing more:
 
 ```csharp
-services.AddMediatR(cfg =>
-{
-    cfg.RegisterGenericHandlers = true;
-
-    // open generic handlers — Application layer
-    cfg.RegisterServicesFromAssembly(
-        typeof(IntegratoR.Application.Features.Common.Commands.CreateCommandHandler<>).Assembly);
-
-    // F&O open handlers (CreateLedgerJournalHeaderHandler<TEntity>, …)
-    cfg.RegisterServicesFromAssembly(
-        typeof(IntegratoR.OData.FO.Domain.Entities.LedgerJournal.LedgerJournalHeader).Assembly);
-
-    // the assembly holding your extended entities
-    cfg.RegisterServicesFromAssembly(typeof(MyLedgerJournalLine).Assembly);
-});
+services.AddIntegratoR(configuration, integrator =>
+    integrator.AddConsumerHandlers(typeof(MyLedgerJournalLine).Assembly));
 ```
 
-The service layer (`IService<MyEntity>`) is **not** the problem here — it is registered as an open generic and resolves against any type. Only the MediatR handler closing is missing.
+`AddConsumerHandlers` folds the assembly into the combined generic-handler scan, so `mediator.Send(new CreateCommand<MyLedgerJournalLine>(...))` — and `Update` / `Delete` / `GetByKey` / `GetByFilter` — resolves automatically (and the assembly's FluentValidation validators are registered too). The service layer (`IService<MyEntity>`) was never the problem — it is an open-generic registration that resolves against any type.
 
 ### A field I need on create or update is dropped from the payload (wrong `IgnoreOnCreate` / `IgnoreOnUpdate`)
 

--- a/wiki/Understand-the-Architecture.md
+++ b/wiki/Understand-the-Architecture.md
@@ -117,11 +117,11 @@ The `AddIntegratoR(configuration, configure)` call performs six steps in this or
 1. `AddApplicationServices()` — pipeline behaviours, MediatR, cache service, OAuth authenticator
 2. `AddODataClient(configuration)` — HTTP client, Polly policies, OData client, `IService<T>` registration
 3. `AddODataClientFOProxy(configuration)` — F&O handlers, F&O entity bindings
-4. Cross-assembly MediatR closing — second `AddMediatR` call that scans both Application and F&O assemblies so generic CRUD handlers close against F&O entity types
+4. Cross-assembly MediatR closing — second `AddMediatR` call that scans the Application, F&O, **and** consumer assemblies together so generic CRUD handlers close against F&O **and** consumer entity types
 5. Durable Functions data converter — registers `JsonDataConverter` with the STJ Result converters on `DurableTaskWorkerOptions`
-6. Consumer assembly registration — for each assembly passed to `AddConsumerHandlers`, calls `AddMediatR(...)` and `AddValidatorsFromAssembly(...)`
+6. Consumer validator registration — for each assembly passed to `AddConsumerHandlers`, calls `AddValidatorsFromAssembly(...)` (its MediatR handlers are already registered by the combined scan in step 4)
 
-Step 4 exists because MediatR v12's `RegisterGenericHandlers = true` flag only closes open-generic handlers against types in the **same** scanned assembly. The generic CRUD handlers live in `IntegratoR.Application`, F&O entities live in `IntegratoR.OData.FO` — the layer-local `AddMediatR` calls in steps 1–3 never see them together, so no closed `IRequestHandler<CreateCommand<LedgerJournalHeader>, ...>` registration would be emitted without step 4.
+Step 4 exists because MediatR v12's `RegisterGenericHandlers = true` flag only closes open-generic handlers against types in the **same** scanned assembly. The generic CRUD handlers live in `IntegratoR.Application`, F&O entities live in `IntegratoR.OData.FO` — the layer-local `AddMediatR` calls in steps 1–3 never see them together, so no closed `IRequestHandler<CreateCommand<LedgerJournalHeader>, ...>` registration would be emitted without step 4. The same scan folds in every assembly passed to `AddConsumerHandlers(...)`, so a consumer's extended or custom entities get closed generic handlers exactly like the framework's own.
 
 ## Dependency Direction
 


### PR DESCRIPTION
## Summary

- Fixes the documented "no service available for extended base entities" gap: `AddIntegratoR` now closes the framework's **generic** CRUD/query MediatR handlers over **consumer-supplied** entities (registered via `AddConsumerHandlers`), not just the framework's own F&O entities.
- Mechanism: step 3b folds `builder.ConsumerAssemblies` into the **same** `RegisterGenericHandlers = true` scan as the Application + OData.FO assemblies; step 6 is slimmed to validator registration only (avoids a duplicate handler scan). ~6 net lines of production code.
- Adds **5 regression tests** (Create / Update / Delete / GetByKey / GetByFilter) for a `ConsumerExtendedEntity` defined in the test assembly — they fail before the fix, pass after.
- Retracts the wiki that described this as a *known limitation* with a manual combined-`AddMediatR` workaround; `AddConsumerHandlers(typeof(MyEntity).Assembly)` is now the one-line answer.

## Risks & rollback

- **Behaviour change, additive.** Consumer entities now get closed handlers automatically. **No public API/signature change** (`AddConsumerHandlers` is unchanged) → not a breaking change; PATCH-level.
- The one subtlety is moving the consumer MediatR scan from step 6 into step 3b. Verified **no double-registration**: full suite **528 passing**, including every existing F&O handler test.
- Build (Release) 0 errors; 528 tests pass (+3 pre-existing skips).
- **Rollback:** revert the two commits.

## Reviewer focus

- `ServiceCollectionExtensions.cs` step 3b / step 6 — that folding consumer assemblies into the `RegisterGenericHandlers` scan is correct and that removing the step-6 `AddMediatR` drops no consumer handler registration (step 3b now covers it).
- The 5 new tests mirror the existing F&O handler tests (`BuildProviderWithSubstitutedConsumerService` + the consumer fixture) — real DI-handler-resolution behaviour, not structural.
- No production API surface changed; no auth/security surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)