### PR TITLE
chore(deps): bump Microsoft.NET.Test.Sdk to 18.5.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,7 +58,7 @@
 
   <ItemGroup Label="Testing">
     <PackageVersion Include="FluentAssertions" Version="8.10.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
Applies Dependabot #101, whose branch conflicted with the already-merged FluentAssertions bump (adjacent line in `Directory.Packages.props`). Test-host SDK only — no runtime/consumer impact; 18.5.1 is the corrected listed release and fixes a .NET 10 traits regression. Build + 490 tests green locally.

Closes #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)