### PR TITLE
feat: pipeline-behaviour + auth/security hardening (PR-A)

### DIFF
--- a/IntegratoR.Abstractions/Common/Results/ResultFactory.cs
+++ b/IntegratoR.Abstractions/Common/Results/ResultFactory.cs
@@ -1,0 +1,56 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using FluentResults;
+
+namespace IntegratoR.Abstractions.Common.Results;
+
+/// <summary>
+/// Creates failed <see cref="Result"/> / <see cref="Result{TValue}"/> instances from an
+/// <see cref="IError"/> when the concrete result type is only known through a generic type
+/// parameter. The per-type <see cref="MethodInfo"/> for <c>Result.Fail&lt;T&gt;(IError)</c> is
+/// cached so the reflection lookup happens at most once per closed result type.
+/// </summary>
+/// <remarks>
+/// This is the single owned implementation of the cached-reflection failure factory. Both
+/// <c>ValidationBehaviour</c> (in IntegratoR.Application) and <c>ODataExceptionHandler</c> (in
+/// IntegratoR.OData) delegate here; because those are separate assemblies from
+/// IntegratoR.Abstractions the type must be public.
+/// </remarks>
+public static class ResultFactory
+{
+    private static readonly ConcurrentDictionary<Type, MethodInfo> FailSingleErrorCache = new();
+
+    /// <summary>
+    /// Builds a failed <typeparamref name="TResult"/> carrying <paramref name="error"/>. Supports
+    /// the non-generic <see cref="Result"/> and the generic <see cref="Result{TValue}"/>; any other
+    /// <see cref="IResultBase"/> type throws <see cref="NotSupportedException"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The closed result type to produce.</typeparam>
+    /// <param name="error">The error the failed result carries.</param>
+    public static TResult FailFromError<TResult>(IError error) where TResult : IResultBase
+    {
+        Type resultType = typeof(TResult);
+        if (resultType.IsGenericType && resultType.GetGenericTypeDefinition() == typeof(Result<>))
+        {
+            MethodInfo failMethod = FailSingleErrorCache.GetOrAdd(
+                resultType.GetGenericArguments()[0],
+                static valueType => typeof(Result)
+                    .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                    .First(m => m.Name == nameof(Result.Fail)
+                        && m.IsGenericMethod
+                        && m.GetParameters().Length == 1
+                        && m.GetParameters()[0].ParameterType == typeof(IError))
+                    .MakeGenericMethod(valueType));
+
+            return (TResult)failMethod.Invoke(null, [error])!;
+        }
+
+        if (resultType == typeof(Result))
+        {
+            return (TResult)(object)Result.Fail(error);
+        }
+
+        throw new NotSupportedException(
+            $"ResultFactory.FailFromError supports Result and Result<T> only; '{resultType.FullName}' is not supported.");
+    }
+}

--- a/IntegratoR.Abstractions/Interfaces/Authentication/IAuthenticator.cs
+++ b/IntegratoR.Abstractions/Interfaces/Authentication/IAuthenticator.cs
@@ -32,5 +32,20 @@ public interface IAuthenticator
     /// contains the access token string, ready to be used in an HTTP Authorization header (e.g., "Bearer {token}").
     /// On failure, it contains a structured <see cref="Error"/> detailing the reason for the authentication failure.
     /// </returns>
+    [Obsolete("Since v1.4.0; use the overload that accepts a CancellationToken.")]
     Task<Result<string>> GetAccessTokenAsync(string clientId, string clientSecret, string tenantId, string resource);
+
+    /// <summary>
+    /// Asynchronously acquires a valid OAuth 2.0 access token for a specified D365 F&amp;O resource.
+    /// </summary>
+    /// <param name="clientId">The Client ID (or Application ID) of the Azure AD App Registration.</param>
+    /// <param name="clientSecret">The Client Secret of the Azure AD App Registration.</param>
+    /// <param name="tenantId">The Azure AD Tenant ID where the application is registered.</param>
+    /// <param name="resource">The URI of the target resource/API to which access is being requested.</param>
+    /// <param name="cancellationToken">A token to observe while waiting for the token acquisition to complete.</param>
+    /// <returns>
+    /// A <see cref="Task"/> that resolves to a <see cref="Result{TValue}"/> carrying the access token on
+    /// success, or a structured error on failure.
+    /// </returns>
+    Task<Result<string>> GetAccessTokenAsync(string clientId, string clientSecret, string tenantId, string resource, CancellationToken cancellationToken);
 }

--- a/IntegratoR.Application/Common/Authentication/OAuthAuthenticator.cs
+++ b/IntegratoR.Application/Common/Authentication/OAuthAuthenticator.cs
@@ -1,3 +1,6 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
 using FluentResults;
 using IntegratoR.Abstractions.Common.Results;
 using IntegratoR.Abstractions.Interfaces.Authentication;
@@ -22,43 +25,60 @@ namespace IntegratoR.Application.Common.Authentication;
 /// </summary>
 /// <remarks>
 /// This implementation is responsible for the entire token lifecycle: checking the cache,
-/// acquiring a new token from Azure AD if necessary, and caching it for future use.
+/// acquiring a new token from Azure AD if necessary, and caching it for future use. The built
+/// <see cref="IConfidentialClientApplication"/> is reused per (clientId, tenantId, resource) so
+/// MSAL's own in-memory token cache is consulted before a network call is made.
 ///
-/// **Important Architectural Note:** This implementation uses <see cref="IMemoryCache"/>,
-/// which is local to a single server instance. While suitable for single-instance applications
-/// or development environments, it is **not appropriate** for stateless, multi-instance environments
-/// like Azure Functions on a Consumption Plan. In a scaled-out scenario, each function instance
-/// would have its own separate cache, leading to unnecessary token requests. For such environments,
-/// an implementation using <c>IDistributedCache</c> (backed by a service like Azure Cache for Redis)
-/// should be used instead to share the token across all instances.
+/// **Important Architectural Note:** the proactive-expiry token cache uses <see cref="IMemoryCache"/>,
+/// which is local to a single instance. For scaled-out, multi-instance environments an
+/// <c>IDistributedCache</c>-backed implementation should be used instead.
 /// </remarks>
 public class OAuthAuthenticator : IAuthenticator
 {
+    // Reuse the built confidential-client app per (clientId, tenantId, resource) so MSAL's internal
+    // token cache is reused instead of being discarded on every IMemoryCache miss.
+    private static readonly ConcurrentDictionary<string, IConfidentialClientApplication> AppCache = new();
+
     private readonly IMemoryCache _memoryCache;
+    private readonly Func<string, string, string, string, IConfidentialClientApplication> _appFactory;
+    private readonly Func<IConfidentialClientApplication, string[], CancellationToken, Task<AcquiredToken>> _tokenAcquirer;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OAuthAuthenticator"/> class.
     /// </summary>
     /// <param name="memoryCache">The memory cache instance, injected via dependency injection.</param>
     public OAuthAuthenticator(IMemoryCache memoryCache)
+        : this(memoryCache, DefaultAppFactory, DefaultAcquireAsync)
+    {
+    }
+
+    /// <summary>
+    /// Test seam constructor. Lets unit tests substitute the confidential-client app factory and the
+    /// token-acquisition delegate so the MSAL network path can be exercised without a real Azure AD.
+    /// </summary>
+    internal OAuthAuthenticator(
+        IMemoryCache memoryCache,
+        Func<string, string, string, string, IConfidentialClientApplication> appFactory,
+        Func<IConfidentialClientApplication, string[], CancellationToken, Task<AcquiredToken>> tokenAcquirer)
     {
         _memoryCache = memoryCache;
+        _appFactory = appFactory;
+        _tokenAcquirer = tokenAcquirer;
     }
 
     /// <inheritdoc />
+    [Obsolete("Since v1.4.0; use the overload that accepts a CancellationToken.")]
+    public Task<Result<string>> GetAccessTokenAsync(string clientId, string clientSecret, string tenantId, string resource)
+        => GetAccessTokenAsync(clientId, clientSecret, tenantId, resource, CancellationToken.None);
+
+    /// <inheritdoc />
     /// <remarks>
-    /// This method first attempts to retrieve a valid token from the in-memory cache. If a token is
-    /// not found, it uses the MSAL <see cref="ConfidentialClientApplicationBuilder"/> to construct a
-    /// request to Azure AD.
-    ///
-    /// It uses the modern `/.default` scope, which is the recommended approach for the client
-    /// credentials flow, requesting all statically-defined application permissions for the given resource.
-    ///
-    /// Upon successful acquisition, the token is cached with a proactive expiration buffer of 5 minutes.
-    /// This is a crucial best practice to prevent race conditions and clock skew issues where the
-    /// application might attempt to use a token just as it expires.
+    /// Attempts to serve a cached token first; on a miss it acquires a new token via the reused
+    /// confidential-client app using the <c>/.default</c> scope, then caches it with a 5-minute
+    /// proactive-expiry buffer. All MSAL failures (service and client) are mapped to a failed
+    /// <see cref="Result{TValue}"/> rather than thrown.
     /// </remarks>
-    public async Task<Result<string>> GetAccessTokenAsync(string clientId, string clientSecret, string tenantId, string resource)
+    public async Task<Result<string>> GetAccessTokenAsync(string clientId, string clientSecret, string tenantId, string resource, CancellationToken cancellationToken)
     {
         // A unique cache key is generated based on the client and resource to ensure
         // tokens for different applications or environments do not collide.
@@ -71,30 +91,53 @@ public class OAuthAuthenticator : IAuthenticator
 
         try
         {
-            var confidentialClientApp = ConfidentialClientApplicationBuilder
-                .Create(clientId)
-                .WithClientSecret(clientSecret)
-                .WithAuthority(new Uri($"https://login.microsoftonline.com/{tenantId}"))
-                .Build();
+            // Include a hash of the secret in the cache key so a rotated client secret yields a fresh
+            // app (with a fresh MSAL token cache) instead of silently reusing a stale one. The raw
+            // secret is never placed in the key.
+            var secretHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(clientSecret)));
+            var appKey = $"{clientId}|{tenantId}|{resource}|{secretHash}";
+            IConfidentialClientApplication confidentialClientApp =
+                AppCache.GetOrAdd(appKey, _ => _appFactory(clientId, clientSecret, tenantId, resource));
 
-            // The "/.default" scope requests all application-level permissions that have been
-            // granted to this application registration for the specified resource.
+            // The "/.default" scope requests all application-level permissions granted to this
+            // application registration for the specified resource.
             var scopes = new[] { $"{resource}/.default" };
-            var authResult = await confidentialClientApp.AcquireTokenForClient(scopes).ExecuteAsync().ConfigureAwait(false);
+            AcquiredToken token = await _tokenAcquirer(confidentialClientApp, scopes, cancellationToken).ConfigureAwait(false);
 
-            // Proactively expire the cache entry 5 minutes before the actual token expires
-            // to avoid using an invalidated token due to clock skew or transit delays.
-            var cacheExpiration = authResult.ExpiresOn.Subtract(TimeSpan.FromMinutes(5));
-            _memoryCache.Set(tokenCacheKey, authResult.AccessToken, cacheExpiration);
+            // Proactively expire the cache entry 5 minutes before the actual token expires to avoid
+            // using an invalidated token due to clock skew or transit delays.
+            var cacheExpiration = token.ExpiresOn.Subtract(TimeSpan.FromMinutes(5));
+            _memoryCache.Set(tokenCacheKey, token.AccessToken, cacheExpiration);
 
-            return Result.Ok(authResult.AccessToken);
+            return Result.Ok(token.AccessToken);
         }
-        catch (MsalServiceException ex)
+        catch (MsalException ex)
         {
-            // Catching the specific MSAL exception allows us to create a rich, structured error
-            // that is agnostic of the underlying library, providing a stable error contract.
-            // The MSAL error code is included for easier debugging.
-            return Result.Fail<string>(new IntegrationError($"Auth.Msal.{ex.ErrorCode}", ex.Message, ErrorType.Failure, ex));
+            // Catch the MSAL BASE type so both MsalServiceException and MsalClientException map to a
+            // structured failed Result (never thrown). The short MSAL error code (e.g. "invalid_client")
+            // is safe to surface; the full ex.Message can carry AADSTS codes / tenant IDs, so it is kept
+            // only on the inner exception for server-side diagnostics, never in the error message.
+            var code = string.IsNullOrEmpty(ex.ErrorCode) ? "Unknown" : ex.ErrorCode;
+            return Result.Fail<string>(new IntegrationError($"Auth.Msal.{code}", "Token acquisition failed", ErrorType.Failure, ex));
         }
     }
+
+    private static IConfidentialClientApplication DefaultAppFactory(string clientId, string clientSecret, string tenantId, string resource)
+        => ConfidentialClientApplicationBuilder
+            .Create(clientId)
+            .WithClientSecret(clientSecret)
+            .WithAuthority(new Uri($"https://login.microsoftonline.com/{tenantId}"))
+            .Build();
+
+    private static async Task<AcquiredToken> DefaultAcquireAsync(IConfidentialClientApplication app, string[] scopes, CancellationToken cancellationToken)
+    {
+        AuthenticationResult result = await app.AcquireTokenForClient(scopes).ExecuteAsync(cancellationToken).ConfigureAwait(false);
+        return new AcquiredToken(result.AccessToken, result.ExpiresOn);
+    }
 }
+
+/// <summary>
+/// Minimal token-acquisition result used by the <see cref="OAuthAuthenticator"/> test seam so the
+/// acquisition path can be substituted without constructing an MSAL <see cref="AuthenticationResult"/>.
+/// </summary>
+internal sealed record AcquiredToken(string AccessToken, DateTimeOffset ExpiresOn);

--- a/IntegratoR.Application/Common/Behaviours/LoggingBehaviour.cs
+++ b/IntegratoR.Application/Common/Behaviours/LoggingBehaviour.cs
@@ -62,7 +62,10 @@ public class LoggingBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest,
         using (_logger.BeginScope(contextDictionary))
         {
             var requestName = typeof(TRequest).Name;
-            _logger.LogInformation("Handling {RequestName} with data: {@Request}", requestName, request);
+            _logger.LogInformation("Handling {RequestName}", requestName);
+            // The full request payload is intentionally logged only at Debug (off by default in
+            // production) to avoid emitting PII / secrets to Information-level sinks such as Application Insights.
+            _logger.LogDebug("Request payload for {RequestName}: {@Request}", requestName, request);
 
             var stopwatch = Stopwatch.StartNew();
 
@@ -71,14 +74,14 @@ public class LoggingBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest,
                 var response = await next().ConfigureAwait(false);
                 stopwatch.Stop();
 
-                if (response is Result { IsFailed: true } result)
+                if (response is IResultBase { IsFailed: true } baseResult)
                 {
                     _logger.LogWarning(
                         "Handled {RequestName} with failure result in {ElapsedMilliseconds}ms. Error: {ErrorCode} - {ErrorMessage}",
                         requestName,
                         stopwatch.ElapsedMilliseconds,
-                        result.GetError()?.Code,
-                        result.GetError()?.Message);
+                        baseResult.GetError()?.Code,
+                        baseResult.GetError()?.Message);
                 }
                 else
                 {

--- a/IntegratoR.Application/Common/Behaviours/ValidationBehaviour.cs
+++ b/IntegratoR.Application/Common/Behaviours/ValidationBehaviour.cs
@@ -1,5 +1,6 @@
 using FluentResults;
 using FluentValidation;
+using FluentValidation.Results;
 using IntegratoR.Abstractions.Common.Results;
 using MediatR;
 
@@ -69,10 +70,9 @@ public class ValidationBehaviour<TRequest, TResponse> : IPipelineBehavior<TReque
     /// 3. If failures exist, it short-circuits the pipeline and returns a standardized validation error.
     /// 4. If validation succeeds, it calls the next delegate in the pipeline.
     ///
-    /// The complex reflection block for handling failures is necessary to dynamically create the correct
-    /// type of failed <see cref="IResult"/>, as <typeparamref name="TResponse"/> can be either the generic
-    /// <see cref="Result{TValue}"/> or the non-generic <see cref="Result"/>. This allows the behavior
-    /// to be universally applied to any command or query.
+    /// Failed results are produced via <see cref="ResultFactory.FailFromError{TResult}"/>, which builds the
+    /// correct closed type (<see cref="Result{TValue}"/> or the non-generic <see cref="Result"/>) so the
+    /// behaviour applies universally to any command or query.
     /// </remarks>
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
@@ -84,12 +84,14 @@ public class ValidationBehaviour<TRequest, TResponse> : IPipelineBehavior<TReque
 
         var context = new ValidationContext<TRequest>(request);
 
-        // Execute all validators and aggregate their failures.
-        var validationFailures = _validators
-            .Select(validator => validator.Validate(context))
-            .SelectMany(validationResult => validationResult.Errors)
-            .Where(validationFailure => validationFailure is not null)
-            .ToList();
+        // Execute all validators sequentially (so async FluentValidation rules run) and aggregate
+        // their failures, forwarding the CancellationToken to each validator.
+        var validationFailures = new List<ValidationFailure>();
+        foreach (var validator in _validators)
+        {
+            var validationResult = await validator.ValidateAsync(context, cancellationToken).ConfigureAwait(false);
+            validationFailures.AddRange(validationResult.Errors.Where(validationFailure => validationFailure is not null));
+        }
 
         if (validationFailures.Any())
         {
@@ -97,28 +99,11 @@ public class ValidationBehaviour<TRequest, TResponse> : IPipelineBehavior<TReque
             var firstFailure = validationFailures.First();
             var error = new IntegrationError("Validation.Error", firstFailure.ErrorMessage, ErrorType.Validation);
 
-            // Dynamically create the correct type of failed Result (generic or non-generic).
-            var resultType = typeof(TResponse);
-            if (resultType.IsGenericType && resultType.GetGenericTypeDefinition() == typeof(Result<>))
-            {
-                var genericType = resultType.GetGenericArguments()[0];
-                var failMethod = typeof(Result)
-                    .GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
-                    .First(m => m.Name == "Fail" && m.IsGenericMethod
-                        && m.GetParameters().Length == 1
-                        && m.GetParameters()[0].ParameterType == typeof(IError))
-                    .MakeGenericMethod(genericType);
-
-                return (TResponse)failMethod!.Invoke(null, new object[] { error })!;
-            }
-            else
-            {
-                // This handles the non-generic Result case for commands that don't return a value.
-                return (TResponse)(object)Result.Fail(error);
-            }
+            // Build the correctly-typed failed Result (generic or non-generic) via the shared cached factory.
+            return ResultFactory.FailFromError<TResponse>(error);
         }
 
         // If validation was successful, proceed to the next behavior or the handler.
-        return await next();
+        return await next().ConfigureAwait(false);
     }
 }

--- a/IntegratoR.Application/Features/Common/Queries/GetByFilterQueryHandler.cs
+++ b/IntegratoR.Application/Features/Common/Queries/GetByFilterQueryHandler.cs
@@ -51,7 +51,7 @@ public class GetByFilterQueryHandler<TEntity> : IRequestHandler<GetByFilterQuery
     /// </returns>
     public async Task<Result<IEnumerable<TEntity>>> Handle(GetByFilterQuery<TEntity> request, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Handling GetByFilterQuery for {EntityType} with filter: {Filter}", typeof(TEntity).Name, request.Filter.ToString());
+        _logger.LogDebug("Handling GetByFilterQuery for {EntityType} with filter: {Filter}", typeof(TEntity).Name, request.Filter.ToString());
 
         var entitiesResult = await _service.FindAsync(request.Filter, cancellationToken).ConfigureAwait(false);
 

--- a/IntegratoR.OData/Common/Authentication/ODataAuthenticationHandler.cs
+++ b/IntegratoR.OData/Common/Authentication/ODataAuthenticationHandler.cs
@@ -73,7 +73,7 @@ public class ODataAuthenticationHandler : DelegatingHandler
     {
         if (_settings.Authentication.Mode == AuthenticationMode.OAuth)
         {
-            Result<string> tokenResult = await _authenticator.GetAccessTokenAsync(_settings.Authentication.OAuth.ClientId, _settings.Authentication.OAuth.ClientSecret, _settings.Authentication.OAuth.TenantId, _settings.Authentication.OAuth.Resource).ConfigureAwait(false);
+            Result<string> tokenResult = await _authenticator.GetAccessTokenAsync(_settings.Authentication.OAuth.ClientId, _settings.Authentication.OAuth.ClientSecret, _settings.Authentication.OAuth.TenantId, _settings.Authentication.OAuth.Resource, cancellationToken).ConfigureAwait(false);
 
             if (tokenResult.IsSuccess)
             {
@@ -83,7 +83,7 @@ public class ODataAuthenticationHandler : DelegatingHandler
             {
                 return new HttpResponseMessage(HttpStatusCode.Unauthorized)
                 {
-                    ReasonPhrase = $"Failed to acquire F&O OAuth token: {tokenResult.GetError()?.Message}"
+                    ReasonPhrase = "Authentication failed"
                 };
             }
         }

--- a/IntegratoR.OData/Common/Extensions/ApplicationDependencyInjection.cs
+++ b/IntegratoR.OData/Common/Extensions/ApplicationDependencyInjection.cs
@@ -50,6 +50,11 @@ internal static class ApplicationDependencyInjection
 
     private static void AddODataDependencies(this IServiceCollection services)
     {
+        // Fail fast on dangerous or incomplete ODataSettings (an auth header smuggled into
+        // DefaultHeaders, or an authentication mode missing its credentials).
+        services.AddSingleton<IValidateOptions<ODataSettings>, ODataSettingsValidator>();
+        services.AddOptions<ODataSettings>().ValidateOnStart();
+
         // Register supporting services
         services.AddTransient<ODataAuthenticationHandler>();
         services.AddSingleton<ODataMetadataProvider>();

--- a/IntegratoR.OData/Common/Services/ODataExceptionHandler.cs
+++ b/IntegratoR.OData/Common/Services/ODataExceptionHandler.cs
@@ -1,7 +1,5 @@
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net;
-using System.Reflection;
 using System.Text.Json;
 using FluentResults;
 using IntegratoR.Abstractions.Common.Results;
@@ -27,8 +25,6 @@ namespace IntegratoR.OData.Common.Services;
 /// </remarks>
 public class ODataExceptionHandler<TEntity> where TEntity : class, IEntity
 {
-    private static readonly ConcurrentDictionary<Type, MethodInfo> FailSingleErrorCache = new();
-
     private readonly ILogger _logger;
     private readonly string _entityTypeName;
     private readonly AsyncRetryPolicy? _retryPolicy;
@@ -277,7 +273,7 @@ public class ODataExceptionHandler<TEntity> where TEntity : class, IEntity
         var (errorCode, errorMessage, errorType) = code switch
         {
             401 or 403 =>
-                ("Unauthorized", $"Authentication failed: {exception.Message}", ErrorType.Failure),
+                ("Unauthorized", "Authentication or authorisation failure", ErrorType.Failure),
             400 =>
                 ("ValidationFailed",
                     innerErrorDetail is not null
@@ -567,22 +563,7 @@ public class ODataExceptionHandler<TEntity> where TEntity : class, IEntity
     }
 
     private static TResult CreateFailResult<TResult>(IError error) where TResult : IResultBase
-    {
-        if (typeof(TResult).IsGenericType)
-        {
-            var genericType = typeof(TResult).GetGenericArguments()[0];
-            var failMethod = FailSingleErrorCache.GetOrAdd(genericType, type =>
-                typeof(Result)
-                    .GetMethods(BindingFlags.Public | BindingFlags.Static)
-                    .First(m => m.Name == "Fail" && m.IsGenericMethod
-                        && m.GetParameters().Length == 1
-                        && m.GetParameters()[0].ParameterType == typeof(IError))
-                    .MakeGenericMethod(type));
-            return (TResult)failMethod.Invoke(null, [error])!;
-        }
-
-        return (TResult)(object)Result.Fail(error);
-    }
+        => ResultFactory.FailFromError<TResult>(error);
 
     private void LogSuccess(
         OperationContext context,

--- a/IntegratoR.OData/Domain/Settings/ODataSettingsValidator.cs
+++ b/IntegratoR.OData/Domain/Settings/ODataSettingsValidator.cs
@@ -1,0 +1,94 @@
+using Microsoft.Extensions.Options;
+
+namespace IntegratoR.OData.Domain.Settings;
+
+/// <summary>
+/// Validates <see cref="ODataSettings"/> at startup (via <c>ValidateOnStart</c>) and on first use,
+/// turning dangerous or incomplete configuration into a clear, fail-fast error instead of a silent
+/// runtime failure.
+/// </summary>
+/// <remarks>
+/// Two classes of misconfiguration are rejected:
+/// <list type="bullet">
+///   <item><description>An authentication header smuggled into
+///   <see cref="ODataApiManagementSettings.DefaultHeaders"/> (the framework owns the auth header;
+///   a duplicate/forged one in DefaultHeaders is a security risk per the security rules).</description></item>
+///   <item><description>An authentication mode without its required credentials (ApiKey without a
+///   subscription key, or OAuth without complete client-credentials).</description></item>
+/// </list>
+/// </remarks>
+public sealed class ODataSettingsValidator : IValidateOptions<ODataSettings>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, ODataSettings options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var failures = new List<string>();
+
+        // (a) DefaultHeaders must never carry an authentication header — those are set by the
+        //     framework. Compared case-insensitively so 'authorization' cannot slip past 'Authorization'.
+        var forbiddenHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Authorization",
+            "Bearer",
+            "Ocp-Apim-Subscription-Key",
+            options.Authentication.ApiManagement.SubscriptionHeaderKey,
+        };
+
+        foreach (string headerKey in options.Authentication.ApiManagement.DefaultHeaders.Keys)
+        {
+            if (forbiddenHeaders.Contains(headerKey))
+            {
+                failures.Add(
+                    $"ODataSettings.Authentication.ApiManagement.DefaultHeaders must not contain the authentication header '{headerKey}'. " +
+                    "Authentication headers are applied by the framework, not via DefaultHeaders.");
+            }
+        }
+
+        // (b)/(c) The selected authentication mode must have its credentials populated.
+        switch (options.Authentication.Mode)
+        {
+            case AuthenticationMode.ApiKey:
+                if (string.IsNullOrWhiteSpace(options.Authentication.ApiManagement.SubscriptionKey))
+                {
+                    failures.Add("ODataSettings.Authentication.ApiManagement.SubscriptionKey must be set when AuthenticationMode is ApiKey.");
+                }
+
+                if (string.IsNullOrWhiteSpace(options.Authentication.ApiManagement.SubscriptionHeaderKey))
+                {
+                    failures.Add("ODataSettings.Authentication.ApiManagement.SubscriptionHeaderKey must be set when AuthenticationMode is ApiKey (it names the HTTP header that carries the subscription key).");
+                }
+
+                break;
+
+            case AuthenticationMode.OAuth:
+                ODataOAuthSettings oauth = options.Authentication.OAuth;
+                if (string.IsNullOrWhiteSpace(oauth.ClientId))
+                {
+                    failures.Add("ODataSettings.Authentication.OAuth.ClientId must be set when AuthenticationMode is OAuth.");
+                }
+
+                if (string.IsNullOrWhiteSpace(oauth.ClientSecret))
+                {
+                    failures.Add("ODataSettings.Authentication.OAuth.ClientSecret must be set when AuthenticationMode is OAuth.");
+                }
+
+                if (string.IsNullOrWhiteSpace(oauth.TenantId))
+                {
+                    failures.Add("ODataSettings.Authentication.OAuth.TenantId must be set when AuthenticationMode is OAuth.");
+                }
+
+                if (string.IsNullOrWhiteSpace(oauth.Resource))
+                {
+                    failures.Add("ODataSettings.Authentication.OAuth.Resource must be set when AuthenticationMode is OAuth.");
+                }
+
+                break;
+        }
+
+        return failures.Count > 0
+            ? ValidateOptionsResult.Fail(failures)
+            : ValidateOptionsResult.Success;
+    }
+}

--- a/tests/IntegratoR.Abstractions.Tests/Common/Results/ResultFactoryTests.cs
+++ b/tests/IntegratoR.Abstractions.Tests/Common/Results/ResultFactoryTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using FluentResults;
+using IntegratoR.Abstractions.Common.Results;
+using Xunit;
+
+namespace IntegratoR.Abstractions.Tests.Common.Results;
+
+/// <summary>
+/// Tests for <see cref="ResultFactory"/> — the cached-reflection failure factory that builds the
+/// correctly-typed failed result (generic <see cref="Result{T}"/> or non-generic <see cref="Result"/>)
+/// from an <see cref="IError"/> when the concrete result type is only known via a generic parameter.
+/// </summary>
+public class ResultFactoryTests
+{
+    /// <summary>A throwaway value type used to close <see cref="Result{T}"/>.</summary>
+    private sealed record SomeType(string Value);
+
+    [Fact]
+    public void FailFromError_GenericResult_ProducesClosedGenericFailedResult()
+    {
+        // Arrange
+        var error = new IntegrationError("Some.Code", "some message", ErrorType.Failure);
+
+        // Act
+        Result<SomeType> result = ResultFactory.FailFromError<Result<SomeType>>(error);
+
+        // Assert
+        result.Should().BeOfType<Result<SomeType>>();
+        result.IsFailed.Should().BeTrue();
+        result.GetError()!.Code.Should().Be("Some.Code");
+    }
+
+    [Fact]
+    public void FailFromError_NonGenericResult_ProducesNonGenericFailedResult()
+    {
+        // Arrange
+        var error = new IntegrationError("Some.Code", "some message", ErrorType.Failure);
+
+        // Act
+        Result result = ResultFactory.FailFromError<Result>(error);
+
+        // Assert
+        result.Should().BeOfType<Result>();
+        result.IsFailed.Should().BeTrue();
+        result.GetError()!.Code.Should().Be("Some.Code");
+    }
+}

--- a/tests/IntegratoR.Application.Tests/Common/Authentication/OAuthAuthenticatorTests.cs
+++ b/tests/IntegratoR.Application.Tests/Common/Authentication/OAuthAuthenticatorTests.cs
@@ -1,6 +1,9 @@
 using FluentAssertions;
+using IntegratoR.Abstractions.Common.Results;
 using IntegratoR.Application.Common.Authentication;
+using IntegratoR.TestKit.Assertions;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Identity.Client;
 using NSubstitute;
 using Xunit;
 
@@ -9,6 +12,12 @@ namespace IntegratoR.Application.Tests.Common.Authentication;
 /// <summary>
 /// Tests for <see cref="OAuthAuthenticator"/>.
 /// </summary>
+/// <remarks>
+/// The MSAL network path is exercised via the internal test-seam constructor, which substitutes the
+/// confidential-client app factory and the token-acquisition delegate so no live Azure AD is needed.
+/// The static app-cache inside <see cref="OAuthAuthenticator"/> persists across tests, so every test
+/// here uses a UNIQUE clientId (and matching cache key) to avoid cross-test bleed.
+/// </remarks>
 public class OAuthAuthenticatorTests
 {
     private readonly IMemoryCache _memoryCache = Substitute.For<IMemoryCache>();
@@ -27,7 +36,7 @@ public class OAuthAuthenticatorTests
             });
 
         // Act
-        var result = await sut.GetAccessTokenAsync("client-id", "secret", "tenant-id", "https://resource");
+        var result = await sut.GetAccessTokenAsync("client-id", "secret", "tenant-id", "https://resource", CancellationToken.None);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -52,30 +61,103 @@ public class OAuthAuthenticatorTests
             });
 
         // Act
-        await sut.GetAccessTokenAsync(clientId, "secret", "tenant", resource);
+        await sut.GetAccessTokenAsync(clientId, "secret", "tenant", resource, CancellationToken.None);
 
         // Assert
         _memoryCache.Received(1).TryGetValue(expectedKey, out Arg.Any<object?>());
     }
 
-    [Fact(Skip = "Requires MSAL integration -- live Azure AD not available in unit tests")]
-    public async Task GetAccessTokenAsync_NoCachedToken_AcquiresNewToken()
+    [Fact]
+    public async Task GetAccessTokenAsync_MsalClientException_ReturnsFailWithMsalCode_DoesNotThrow()
     {
-        // This test requires a real MSAL connection and is intentionally skipped in unit tests.
-        await Task.CompletedTask;
+        // Arrange -- the acquirer throws a client-side MSAL error; the cache misses.
+        const string clientId = "msal-client-error-client";
+        var app = Substitute.For<IConfidentialClientApplication>();
+        _memoryCache.TryGetValue(Arg.Any<object>(), out Arg.Any<object?>()).Returns(false);
+
+        var sut = new OAuthAuthenticator(
+            _memoryCache,
+            (_, _, _, _) => app,
+            (_, _, _) => throw new MsalClientException("some_client_error", "bad config"));
+
+        // Act
+        Func<Task> act = async () =>
+        {
+            var result = await sut.GetAccessTokenAsync(clientId, "secret", "tenant", "https://resource", CancellationToken.None);
+
+            // Assert (inside the act delegate so we both prove no-throw AND inspect the result)
+            result.Should().BeFailed();
+            result.Should().HaveErrorCode("Auth.Msal.some_client_error");
+            result.Should().HaveErrorType(ErrorType.Failure);
+        };
+
+        // Assert -- the MSAL exception is mapped to a failed Result, never propagated.
+        await act.Should().NotThrowAsync();
     }
 
-    [Fact(Skip = "Requires MSAL integration to trigger MsalServiceException -- not unit-testable without MSAL mocking")]
-    public async Task GetAccessTokenAsync_MsalServiceException_ReturnsIntegrationError()
+    [Fact]
+    public async Task GetAccessTokenAsync_NoCachedToken_SuccessPath_CachesAndReturnsToken()
     {
-        // This test requires MSAL internals to be mockable.
-        await Task.CompletedTask;
+        // Arrange -- real MemoryCache so the success path actually caches; unique clientId.
+        const string clientId = "success-path-unique-client";
+        const string resource = "https://success-resource";
+        using var realCache = new MemoryCache(new MemoryCacheOptions());
+        var app = Substitute.For<IConfidentialClientApplication>();
+
+        var acquirerCallCount = 0;
+        var sut = new OAuthAuthenticator(
+            realCache,
+            (_, _, _, _) => app,
+            (_, _, _) =>
+            {
+                acquirerCallCount++;
+                return Task.FromResult(new AcquiredToken("new-token", DateTimeOffset.UtcNow.AddHours(1)));
+            });
+
+        // Act -- first call acquires and caches.
+        var first = await sut.GetAccessTokenAsync(clientId, "secret", "tenant", resource, CancellationToken.None);
+
+        // Assert
+        first.Should().BeSuccessful();
+        first.Should().HaveValue("new-token");
+
+        // Act -- second call must be served from the cache without re-invoking the acquirer.
+        var second = await sut.GetAccessTokenAsync(clientId, "secret", "tenant", resource, CancellationToken.None);
+
+        // Assert
+        second.Should().BeSuccessful();
+        second.Should().HaveValue("new-token");
+        acquirerCallCount.Should().Be(1);
     }
 
-    [Fact(Skip = "Requires MSAL integration to trigger MsalException -- not unit-testable without MSAL mocking")]
-    public async Task GetAccessTokenAsync_MsalException_ErrorCodeContainsMsalErrorCode()
+    [Fact]
+    public async Task GetAccessTokenAsync_TwoCacheMisses_ReuseSameConfidentialClientAppInstance()
     {
-        // This test requires MSAL internals to be mockable.
-        await Task.CompletedTask;
+        // Arrange -- token-cache misses both times, so only the static app-cache can prevent a
+        // rebuild. A unique clientId|tenantId|resource keeps the static cache key isolated.
+        const string clientId = "app-cache-reuse-unique-client";
+        const string tenantId = "app-cache-reuse-tenant";
+        const string resource = "https://app-cache-reuse-resource";
+
+        _memoryCache.TryGetValue(Arg.Any<object>(), out Arg.Any<object?>()).Returns(false);
+
+        var app = Substitute.For<IConfidentialClientApplication>();
+        var appFactoryCallCount = 0;
+
+        var sut = new OAuthAuthenticator(
+            _memoryCache,
+            (_, _, _, _) =>
+            {
+                appFactoryCallCount++;
+                return app;
+            },
+            (_, _, _) => Task.FromResult(new AcquiredToken("token", DateTimeOffset.UtcNow.AddHours(1))));
+
+        // Act -- two calls with identical client/tenant/resource.
+        await sut.GetAccessTokenAsync(clientId, "secret", tenantId, resource, CancellationToken.None);
+        await sut.GetAccessTokenAsync(clientId, "secret", tenantId, resource, CancellationToken.None);
+
+        // Assert -- the confidential-client app was built exactly once and reused.
+        appFactoryCallCount.Should().Be(1);
     }
 }

--- a/tests/IntegratoR.Application.Tests/Common/Behaviours/LoggingBehaviourTests.cs
+++ b/tests/IntegratoR.Application.Tests/Common/Behaviours/LoggingBehaviourTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using FluentResults;
+using IntegratoR.Abstractions.Common.Results;
 using IntegratoR.Abstractions.Interfaces.Telemetry;
 using IntegratoR.Application.Common.Behaviours;
 using MediatR;
@@ -27,6 +28,56 @@ public class LoggingBehaviourTests
             new Dictionary<string, object> { { "TestKey", "TestValue" } };
     }
 
+    /// <summary>
+    /// A test request returning a generic <see cref="Result{T}"/>, used to prove the failure path
+    /// matches via <see cref="IResultBase"/> (the old <c>is Result</c> check only matched non-generic).
+    /// Carries a sensitive payload to verify the Information log never destructures the request body.
+    /// </summary>
+    public record TestSensitiveRequest(string Secret) : IRequest<Result<string>>, IContext
+    {
+        /// <summary>Returns logging context for this request.</summary>
+        public IReadOnlyDictionary<string, object> GetLoggingContext() =>
+            new Dictionary<string, object> { { "TestKey", "TestValue" } };
+    }
+
+    /// <summary>
+    /// Renders every captured <see cref="ILogger.Log{TState}"/> call at <paramref name="level"/> to its
+    /// final string by invoking the captured formatter delegate, so assertions can inspect the rendered
+    /// message content rather than just the level.
+    /// </summary>
+    private static IEnumerable<string> RenderedMessages<TState, TResponse>(
+        ILogger<LoggingBehaviour<TState, TResponse>> logger,
+        LogLevel level)
+        where TState : IRequest<TResponse>, IContext
+    {
+        foreach (var call in logger.ReceivedCalls())
+        {
+            if (call.GetMethodInfo().Name != nameof(ILogger.Log))
+            {
+                continue;
+            }
+
+            object?[] args = call.GetArguments();
+            if (args[0] is not LogLevel callLevel || callLevel != level)
+            {
+                continue;
+            }
+
+            // args: [LogLevel, EventId, TState state, Exception?, Func<TState, Exception?, string> formatter]
+            object? state = args[2];
+            object? formatter = args[4];
+            if (formatter is null)
+            {
+                continue;
+            }
+
+            string rendered = (string)formatter.GetType()
+                .GetMethod("Invoke")!
+                .Invoke(formatter, [state, args[3]])!;
+            yield return rendered;
+        }
+    }
+
     [Fact]
     public async Task Handle_SuccessfulRequest_LogsStartAndCompletionWithElapsedTime()
     {
@@ -39,13 +90,28 @@ public class LoggingBehaviourTests
         // Act
         var result = await sut.Handle(request, next, CancellationToken.None);
 
-        // Assert -- LoggingBehaviour emits: 1x Info (start), 1x Info (completion), 1x Debug (response) = 3 calls total
+        // Assert -- LoggingBehaviour emits: 1x Info (start), 1x Debug (request payload),
+        // 1x Info (completion), 1x Debug (response) = 4 calls total.
         result.IsSuccess.Should().BeTrue();
-        _logger.ReceivedWithAnyArgs(3).Log(
+        _logger.ReceivedWithAnyArgs(4).Log(
             Arg.Any<LogLevel>(),
             Arg.Any<EventId>(),
             Arg.Any<object>(),
             Arg.Any<Exception>(),
+            Arg.Any<Func<object, Exception?, string>>());
+
+        // Two Information lines (start + completion) and two Debug lines (request payload + response).
+        _logger.Received(2).Log(
+            LogLevel.Information,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+        _logger.Received(2).Log(
+            LogLevel.Debug,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception?>(),
             Arg.Any<Func<object, Exception?, string>>());
     }
 
@@ -129,5 +195,61 @@ public class LoggingBehaviourTests
             Arg.Any<object>(),
             Arg.Any<Exception?>(),
             Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    /// <summary>
+    /// Regression: a failed <see cref="Result{T}"/> (generic) must be logged as a Warning carrying the
+    /// error code and message, and the success Information line must NOT be emitted. The pre-fix code
+    /// matched only the non-generic <c>is Result</c>, so a failed <c>Result&lt;string&gt;</c> slipped
+    /// through the success branch — this test fails on that code.
+    /// </summary>
+    [Fact]
+    public async Task Handle_FailedResultOfT_LogsWarningWithErrorCodeAndMessage()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger<LoggingBehaviour<TestSensitiveRequest, Result<string>>>>();
+        var sut = new LoggingBehaviour<TestSensitiveRequest, Result<string>>(logger);
+        var request = new TestSensitiveRequest("irrelevant");
+        var next = Substitute.For<RequestHandlerDelegate<Result<string>>>();
+        next(Arg.Any<CancellationToken>())
+            .Returns(Result.Fail<string>(new IntegrationError("Some.Code", "some message", ErrorType.Failure)));
+
+        // Act
+        var result = await sut.Handle(request, next, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+
+        string[] warnings = RenderedMessages(logger, LogLevel.Warning).ToArray();
+        warnings.Should().ContainSingle();
+        warnings[0].Should().Contain("Some.Code").And.Contain("some message");
+
+        // No "successfully" Information line should have been emitted.
+        RenderedMessages(logger, LogLevel.Information)
+            .Should().NotContain(message => message.Contains("successfully"));
+    }
+
+    /// <summary>
+    /// The Information-level logs must never destructure the request body. The request payload is
+    /// only emitted at Debug via <c>{@Request}</c>; a sensitive value carried on the request must
+    /// not appear in any Information-rendered message.
+    /// </summary>
+    [Fact]
+    public async Task Handle_InformationLog_DoesNotDestructureRequestBody()
+    {
+        // Arrange
+        const string sentinel = "SENSITIVE-TOKEN";
+        var logger = Substitute.For<ILogger<LoggingBehaviour<TestSensitiveRequest, Result<string>>>>();
+        var sut = new LoggingBehaviour<TestSensitiveRequest, Result<string>>(logger);
+        var request = new TestSensitiveRequest(sentinel);
+        var next = Substitute.For<RequestHandlerDelegate<Result<string>>>();
+        next(Arg.Any<CancellationToken>()).Returns(Result.Ok("ok"));
+
+        // Act
+        await sut.Handle(request, next, CancellationToken.None);
+
+        // Assert -- no Information-level rendered message contains the sentinel.
+        RenderedMessages(logger, LogLevel.Information)
+            .Should().NotContain(message => message.Contains(sentinel));
     }
 }

--- a/tests/IntegratoR.Application.Tests/Common/Behaviours/ValidationBehaviourTests.cs
+++ b/tests/IntegratoR.Application.Tests/Common/Behaviours/ValidationBehaviourTests.cs
@@ -44,8 +44,8 @@ public class ValidationBehaviourTests
     {
         // Arrange
         var validator = Substitute.For<IValidator<TestGenericRequest>>();
-        validator.Validate(Arg.Any<ValidationContext<TestGenericRequest>>())
-            .Returns(new ValidationResult());
+        validator.ValidateAsync(Arg.Any<ValidationContext<TestGenericRequest>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ValidationResult()));
         var sut = new ValidationBehaviour<TestGenericRequest, Result<string>>(
             new[] { validator });
         var request = new TestGenericRequest();
@@ -65,8 +65,8 @@ public class ValidationBehaviourTests
     {
         // Arrange
         var validator = Substitute.For<IValidator<TestGenericRequest>>();
-        validator.Validate(Arg.Any<ValidationContext<TestGenericRequest>>())
-            .Returns(new ValidationResult(new[] { new ValidationFailure("Entity", "Entity is required.") }));
+        validator.ValidateAsync(Arg.Any<ValidationContext<TestGenericRequest>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ValidationResult(new[] { new ValidationFailure("Entity", "Entity is required.") })));
         var sut = new ValidationBehaviour<TestGenericRequest, Result<string>>(new[] { validator });
         var request = new TestGenericRequest();
         var next = Substitute.For<RequestHandlerDelegate<Result<string>>>();
@@ -84,8 +84,8 @@ public class ValidationBehaviourTests
     {
         // Arrange
         var validator = Substitute.For<IValidator<TestGenericRequest>>();
-        validator.Validate(Arg.Any<ValidationContext<TestGenericRequest>>())
-            .Returns(new ValidationResult(new[] { new ValidationFailure("Entity", "Entity is required.") }));
+        validator.ValidateAsync(Arg.Any<ValidationContext<TestGenericRequest>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ValidationResult(new[] { new ValidationFailure("Entity", "Entity is required.") })));
         var sut = new ValidationBehaviour<TestGenericRequest, Result<string>>(new[] { validator });
         var request = new TestGenericRequest();
         var next = Substitute.For<RequestHandlerDelegate<Result<string>>>();
@@ -103,8 +103,8 @@ public class ValidationBehaviourTests
     {
         // Arrange
         var validator = Substitute.For<IValidator<TestGenericRequest>>();
-        validator.Validate(Arg.Any<ValidationContext<TestGenericRequest>>())
-            .Returns(new ValidationResult(new[] { new ValidationFailure("Entity", "Entity is required.") }));
+        validator.ValidateAsync(Arg.Any<ValidationContext<TestGenericRequest>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ValidationResult(new[] { new ValidationFailure("Entity", "Entity is required.") })));
         var sut = new ValidationBehaviour<TestGenericRequest, Result<string>>(new[] { validator });
         var request = new TestGenericRequest();
         var next = Substitute.For<RequestHandlerDelegate<Result<string>>>();
@@ -122,8 +122,8 @@ public class ValidationBehaviourTests
     {
         // Arrange
         var validator = Substitute.For<IValidator<TestGenericRequest>>();
-        validator.Validate(Arg.Any<ValidationContext<TestGenericRequest>>())
-            .Returns(new ValidationResult(new[] { new ValidationFailure("Entity", "Error") }));
+        validator.ValidateAsync(Arg.Any<ValidationContext<TestGenericRequest>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ValidationResult(new[] { new ValidationFailure("Entity", "Error") })));
         var sut = new ValidationBehaviour<TestGenericRequest, Result<string>>(new[] { validator });
         var request = new TestGenericRequest();
         var next = Substitute.For<RequestHandlerDelegate<Result<string>>>();
@@ -141,8 +141,8 @@ public class ValidationBehaviourTests
     {
         // Arrange
         var validator = Substitute.For<IValidator<TestNonGenericRequest>>();
-        validator.Validate(Arg.Any<ValidationContext<TestNonGenericRequest>>())
-            .Returns(new ValidationResult(new[] { new ValidationFailure("Entity", "Error") }));
+        validator.ValidateAsync(Arg.Any<ValidationContext<TestNonGenericRequest>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ValidationResult(new[] { new ValidationFailure("Entity", "Error") })));
         var sut = new ValidationBehaviour<TestNonGenericRequest, Result>(new[] { validator });
         var request = new TestNonGenericRequest();
         var next = Substitute.For<RequestHandlerDelegate<Result>>();
@@ -160,12 +160,12 @@ public class ValidationBehaviourTests
     {
         // Arrange
         var validator = Substitute.For<IValidator<TestGenericRequest>>();
-        validator.Validate(Arg.Any<ValidationContext<TestGenericRequest>>())
-            .Returns(new ValidationResult(new[]
+        validator.ValidateAsync(Arg.Any<ValidationContext<TestGenericRequest>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ValidationResult(new[]
             {
                 new ValidationFailure("Field1", "First error message"),
                 new ValidationFailure("Field2", "Second error message")
-            }));
+            })));
         var sut = new ValidationBehaviour<TestGenericRequest, Result<string>>(new[] { validator });
         var request = new TestGenericRequest();
         var next = Substitute.For<RequestHandlerDelegate<Result<string>>>();
@@ -177,5 +177,57 @@ public class ValidationBehaviourTests
         result.IsFailed.Should().BeTrue();
         result.Errors.Should().HaveCount(1);
         result.Errors.First().Message.Should().Be("First error message");
+    }
+
+    [Fact]
+    public async Task Handle_AsyncValidator_RunsAndForwardsCancellationToken()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        CancellationToken token = cts.Token;
+
+        var validator = Substitute.For<IValidator<TestGenericRequest>>();
+        validator.ValidateAsync(Arg.Any<ValidationContext<TestGenericRequest>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ValidationResult()));
+        var sut = new ValidationBehaviour<TestGenericRequest, Result<string>>(new[] { validator });
+        var request = new TestGenericRequest();
+        var next = Substitute.For<RequestHandlerDelegate<Result<string>>>();
+        next(Arg.Any<CancellationToken>()).Returns(Result.Ok("value"));
+
+        // Act
+        var result = await sut.Handle(request, next, token);
+
+        // Assert -- the validator was invoked asynchronously with the exact token threaded through.
+        result.IsSuccess.Should().BeTrue();
+        await validator.Received(1)
+            .ValidateAsync(Arg.Any<ValidationContext<TestGenericRequest>>(), token);
+    }
+
+    [Fact]
+    public async Task Handle_TwoSeparateValidators_AggregatesFailuresAcrossValidators()
+    {
+        // Arrange
+        var validator1 = Substitute.For<IValidator<TestGenericRequest>>();
+        validator1.ValidateAsync(Arg.Any<ValidationContext<TestGenericRequest>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ValidationResult(new[] { new ValidationFailure("Field1", "First validator error") })));
+
+        var validator2 = Substitute.For<IValidator<TestGenericRequest>>();
+        validator2.ValidateAsync(Arg.Any<ValidationContext<TestGenericRequest>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ValidationResult(new[] { new ValidationFailure("Field2", "Second validator error") })));
+
+        var sut = new ValidationBehaviour<TestGenericRequest, Result<string>>(new[] { validator1, validator2 });
+        var request = new TestGenericRequest();
+        var next = Substitute.For<RequestHandlerDelegate<Result<string>>>();
+
+        // Act
+        var result = await sut.Handle(request, next, CancellationToken.None);
+
+        // Assert -- both validators ran; the first aggregated failure surfaces as the error.
+        await validator1.Received(1).ValidateAsync(Arg.Any<ValidationContext<TestGenericRequest>>(), Arg.Any<CancellationToken>());
+        await validator2.Received(1).ValidateAsync(Arg.Any<ValidationContext<TestGenericRequest>>(), Arg.Any<CancellationToken>());
+        result.IsFailed.Should().BeTrue();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.First().Message.Should().Be("First validator error");
+        await next.DidNotReceive()(Arg.Any<CancellationToken>());
     }
 }

--- a/tests/IntegratoR.Application.Tests/Features/Common/Queries/GetByFilterQueryHandlerTests.cs
+++ b/tests/IntegratoR.Application.Tests/Features/Common/Queries/GetByFilterQueryHandlerTests.cs
@@ -83,4 +83,30 @@ public class GetByFilterQueryHandlerTests
         result.Should().BeSuccessful();
         result.Value.Should().BeEmpty();
     }
+
+    [Fact]
+    public async Task Handle_DoesNotLogAtInformationLevel()
+    {
+        // Arrange -- per-request handler logging was lowered to Debug to keep hot paths quiet.
+        var entities = new List<TestEntity>
+        {
+            new() { Id = "1", PartitionKey = "pk", Name = "Alpha" }
+        };
+        Expression<Func<TestEntity, bool>> filter = e => e.Name != null;
+        var query = new GetByFilterQuery<TestEntity>(filter);
+        _service.FindAsync(filter, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<IEnumerable<TestEntity>>(entities));
+
+        // Act
+        var result = await _sut.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().BeSuccessful();
+        _logger.DidNotReceive().Log(
+            LogLevel.Information,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
 }

--- a/tests/IntegratoR.OData.Tests/Common/Authentication/ODataAuthenticationHandlerTests.cs
+++ b/tests/IntegratoR.OData.Tests/Common/Authentication/ODataAuthenticationHandlerTests.cs
@@ -50,7 +50,7 @@ public class ODataAuthenticationHandlerTests
     {
         // Arrange
         const string token = "test-token";
-        _authenticator.GetAccessTokenAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+        _authenticator.GetAccessTokenAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Result.Ok(token));
 
         _fakeHandler.Queue(HttpStatusCode.OK);
@@ -70,14 +70,19 @@ public class ODataAuthenticationHandlerTests
     }
 
     /// <summary>
-    /// Verifies that a failed OAuth token acquisition returns a 401 response.
+    /// Verifies that a failed OAuth token acquisition returns a 401 response whose ReasonPhrase is a
+    /// fixed, generic string — it must NOT leak the underlying MSAL/AADSTS detail into the HTTP
+    /// response (security: ReasonPhrase must not expose internal error details).
     /// </summary>
     [Fact]
-    public async Task SendAsync_OAuthMode_FailedToken_Returns401Unauthorized()
+    public async Task SendAsync_OAuthMode_FailedToken_Returns401WithGenericReasonPhrase()
     {
-        // Arrange
-        var error = new IntegrationError("Auth.Failed", "Token acquisition failed", ErrorType.Failure);
-        _authenticator.GetAccessTokenAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+        // Arrange -- the failure carries a sensitive MSAL detail that must not surface in the response.
+        var error = new IntegrationError(
+            "Auth.Msal.invalid_client",
+            "AADSTS7000215: Invalid client secret provided.",
+            ErrorType.Failure);
+        _authenticator.GetAccessTokenAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Result.Fail<string>(error));
 
         ODataSettings settings = CreateOAuthSettings();
@@ -89,7 +94,8 @@ public class ODataAuthenticationHandlerTests
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
-        response.ReasonPhrase.Should().Contain("Token acquisition failed");
+        response.ReasonPhrase.Should().Be("Authentication failed");
+        response.ReasonPhrase.Should().NotContain("AADSTS");
     }
 
     /// <summary>
@@ -100,7 +106,7 @@ public class ODataAuthenticationHandlerTests
     {
         // Arrange
         var error = new IntegrationError("Auth.Failed", "Token acquisition failed", ErrorType.Failure);
-        _authenticator.GetAccessTokenAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+        _authenticator.GetAccessTokenAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Result.Fail<string>(error));
 
         ODataSettings settings = CreateOAuthSettings();
@@ -203,7 +209,7 @@ public class ODataAuthenticationHandlerTests
         const string tenantId = "test-tenant-id";
         const string resource = "https://test.operations.dynamics.com";
 
-        _authenticator.GetAccessTokenAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+        _authenticator.GetAccessTokenAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Result.Ok("any-token"));
         _fakeHandler.Queue(HttpStatusCode.OK);
 
@@ -228,6 +234,33 @@ public class ODataAuthenticationHandlerTests
         await invoker.SendAsync(request, CancellationToken.None);
 
         // Assert
-        await _authenticator.Received(1).GetAccessTokenAsync(clientId, clientSecret, tenantId, resource);
+        await _authenticator.Received(1).GetAccessTokenAsync(clientId, clientSecret, tenantId, resource, Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies that OAuth mode forwards the caller's CancellationToken through to the authenticator,
+    /// so a cancelled request short-circuits token acquisition rather than blocking.
+    /// </summary>
+    [Fact]
+    public async Task SendAsync_OAuthMode_ForwardsCancellationTokenToAuthenticator()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        CancellationToken token = cts.Token;
+
+        _authenticator.GetAccessTokenAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok("any-token"));
+        _fakeHandler.Queue(HttpStatusCode.OK);
+
+        ODataSettings settings = CreateOAuthSettings();
+        var invoker = CreateInvoker(settings);
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/test");
+        await invoker.SendAsync(request, token);
+
+        // Assert -- the exact token reached the authenticator.
+        await _authenticator.Received(1).GetAccessTokenAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), token);
     }
 }

--- a/tests/IntegratoR.OData.Tests/Common/Extensions/ApplicationDependencyInjectionTests.cs
+++ b/tests/IntegratoR.OData.Tests/Common/Extensions/ApplicationDependencyInjectionTests.cs
@@ -21,6 +21,19 @@ namespace IntegratoR.OData.Tests.Common.Extensions;
 public class ApplicationDependencyInjectionTests
 {
     /// <summary>
+    /// Applies valid ApiKey credentials to <paramref name="options"/> so the
+    /// <see cref="ODataSettingsValidator"/> (registered with <c>ValidateOnStart</c>) passes when
+    /// <c>IOptions&lt;ODataSettings&gt;.Value</c> is materialised — required by any test that builds
+    /// the provider and reads settings or resolves the HttpClient/ODataClient.
+    /// </summary>
+    private static void ApplyValidApiKeyCredentials(ODataSettings options)
+    {
+        options.Authentication.Mode = AuthenticationMode.ApiKey;
+        options.Authentication.ApiManagement.SubscriptionKey = "test-subscription-key";
+        options.Authentication.ApiManagement.SubscriptionHeaderKey = "Ocp-Apim-Subscription-Key";
+    }
+
+    /// <summary>
     /// Verifies that settings are correctly bound from IConfiguration using the config-based overload.
     /// </summary>
     [Fact]
@@ -33,6 +46,7 @@ public class ApplicationDependencyInjectionTests
                 ["ODataSettings:Url"] = "https://test.operations.dynamics.com/data",
                 ["ODataSettings:Authentication:Mode"] = "OAuth",
                 ["ODataSettings:Authentication:OAuth:ClientId"] = "test-client-id",
+                ["ODataSettings:Authentication:OAuth:ClientSecret"] = "test-client-secret",
                 ["ODataSettings:Authentication:OAuth:TenantId"] = "test-tenant-id",
                 ["ODataSettings:Authentication:OAuth:Resource"] = "https://test.operations.dynamics.com",
             })
@@ -99,6 +113,8 @@ public class ApplicationDependencyInjectionTests
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["ODataSettings:Url"] = "https://test.operations.dynamics.com/data",
+                ["ODataSettings:Authentication:Mode"] = "ApiKey",
+                ["ODataSettings:Authentication:ApiManagement:SubscriptionKey"] = "test-sub-key",
                 ["ODataSettings:MetadataFilePath"] = "metadata.xml",
                 ["ODataSettings:Resilience:EnableRetries"] = "false",
                 ["ODataSettings:Resilience:RetryCount"] = "5",
@@ -142,6 +158,9 @@ public class ApplicationDependencyInjectionTests
         {
             options.Url = "https://action.operations.dynamics.com/data";
             options.Authentication.OAuth.ClientId = "action-client-id";
+            // Mode defaults to ApiKey; supply a subscription key so ODataSettingsValidator
+            // (ValidateOnStart) passes when IOptions<ODataSettings>.Value is materialised below.
+            options.Authentication.ApiManagement.SubscriptionKey = "action-sub-key";
         });
         var provider = services.BuildServiceProvider();
 
@@ -201,7 +220,11 @@ public class ApplicationDependencyInjectionTests
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddSingleton<IAuthenticator>(Substitute.For<IAuthenticator>());
-        services.AddODataClient(options => options.Url = "https://test.example.com");
+        services.AddODataClient(options =>
+        {
+            options.Url = "https://test.example.com";
+            ApplyValidApiKeyCredentials(options);
+        });
 
         // Act
         var provider = services.BuildServiceProvider();
@@ -252,7 +275,11 @@ public class ApplicationDependencyInjectionTests
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddSingleton<IAuthenticator>(Substitute.For<IAuthenticator>());
-        services.AddODataClient(options => options.Url = configuredUrl);
+        services.AddODataClient(options =>
+        {
+            options.Url = configuredUrl;
+            ApplyValidApiKeyCredentials(options);
+        });
 
         var provider = services.BuildServiceProvider();
 
@@ -324,7 +351,11 @@ public class ApplicationDependencyInjectionTests
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddSingleton<IAuthenticator>(Substitute.For<IAuthenticator>());
-        services.AddODataClient(options => options.Url = configuredUrl);
+        services.AddODataClient(options =>
+        {
+            options.Url = configuredUrl;
+            ApplyValidApiKeyCredentials(options);
+        });
 
         var provider = services.BuildServiceProvider();
 
@@ -373,7 +404,11 @@ public class ApplicationDependencyInjectionTests
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddSingleton<IAuthenticator>(Substitute.For<IAuthenticator>());
-        services.AddODataClient(options => options.Url = configuredUrl);
+        services.AddODataClient(options =>
+        {
+            options.Url = configuredUrl;
+            ApplyValidApiKeyCredentials(options);
+        });
 
         var provider = services.BuildServiceProvider();
 
@@ -387,5 +422,63 @@ public class ApplicationDependencyInjectionTests
         // Assert
         settings.Url.Should().Be(configuredUrl);
         settings.Url.Should().NotEndWith("/");
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="ODataSettingsValidator"/> registered with <c>ValidateOnStart</c>
+    /// rejects invalid configuration: materialising <c>IOptions&lt;ODataSettings&gt;.Value</c> throws
+    /// <see cref="OptionsValidationException"/> when OAuth mode is missing a credential OR an
+    /// authentication header is smuggled into DefaultHeaders. A fully valid config resolves cleanly.
+    /// </summary>
+    [Fact]
+    public void AddODataClient_InvalidSettings_ValidateOnStartThrowsOptionsValidationException()
+    {
+        // Arrange — OAuth mode missing ClientSecret (and tenant/resource).
+        var oauthServices = new ServiceCollection();
+        oauthServices.AddLogging();
+        oauthServices.AddSingleton<IAuthenticator>(Substitute.For<IAuthenticator>());
+        oauthServices.AddODataClient(options =>
+        {
+            options.Url = "https://test.example.com";
+            options.Authentication.Mode = AuthenticationMode.OAuth;
+            options.Authentication.OAuth.ClientId = "client-id";
+            // ClientSecret/TenantId/Resource intentionally left blank.
+        });
+        var oauthProvider = oauthServices.BuildServiceProvider();
+
+        // Act / Assert — OAuth missing credentials.
+        Action resolveOAuth = () => _ = oauthProvider.GetRequiredService<IOptions<ODataSettings>>().Value;
+        resolveOAuth.Should().Throw<OptionsValidationException>();
+
+        // Arrange — forbidden Authorization header smuggled into DefaultHeaders (otherwise valid ApiKey).
+        var headerServices = new ServiceCollection();
+        headerServices.AddLogging();
+        headerServices.AddSingleton<IAuthenticator>(Substitute.For<IAuthenticator>());
+        headerServices.AddODataClient(options =>
+        {
+            options.Url = "https://test.example.com";
+            ApplyValidApiKeyCredentials(options);
+            options.Authentication.ApiManagement.DefaultHeaders["Authorization"] = "Bearer leaked";
+        });
+        var headerProvider = headerServices.BuildServiceProvider();
+
+        // Act / Assert — forbidden header.
+        Action resolveHeader = () => _ = headerProvider.GetRequiredService<IOptions<ODataSettings>>().Value;
+        resolveHeader.Should().Throw<OptionsValidationException>();
+
+        // Arrange — fully valid ApiKey config must resolve without throwing.
+        var validServices = new ServiceCollection();
+        validServices.AddLogging();
+        validServices.AddSingleton<IAuthenticator>(Substitute.For<IAuthenticator>());
+        validServices.AddODataClient(options =>
+        {
+            options.Url = "https://test.example.com";
+            ApplyValidApiKeyCredentials(options);
+        });
+        var validProvider = validServices.BuildServiceProvider();
+
+        // Act / Assert — valid config resolves cleanly.
+        Action resolveValid = () => _ = validProvider.GetRequiredService<IOptions<ODataSettings>>().Value;
+        resolveValid.Should().NotThrow();
     }
 }

--- a/tests/IntegratoR.OData.Tests/Common/Services/ODataExceptionHandlerTests.cs
+++ b/tests/IntegratoR.OData.Tests/Common/Services/ODataExceptionHandlerTests.cs
@@ -200,6 +200,29 @@ public class ODataExceptionHandlerTests
     }
 
     /// <summary>
+    /// Security: a 401 must map to a fixed, generic error message that does NOT echo the underlying
+    /// exception detail (tenant IDs, AADSTS codes, MSAL specifics). The message is the constant
+    /// "Authentication or authorisation failure" — the full detail stays server-side in the log only.
+    /// </summary>
+    [Fact]
+    public async Task HandleException_Unauthorized_MessageIsGenericAndOmitsExceptionDetail()
+    {
+        // Arrange
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.ExecuteAsync(
+            "Test",
+            () => throw new ODataUnauthorizedException("AADSTS500011 tenant 1111-2222-3333 directory not found"),
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Should().BeFailed();
+        result.GetError()!.Message.Should().Be("Authentication or authorisation failure");
+        result.GetError()!.Message.Should().NotContain("AADSTS");
+    }
+
+    /// <summary>
     /// Verifies that ODataForbiddenException maps to the Unauthorized error code.
     /// </summary>
     [Fact]

--- a/tests/IntegratoR.OData.Tests/Domain/Settings/ODataSettingsValidatorTests.cs
+++ b/tests/IntegratoR.OData.Tests/Domain/Settings/ODataSettingsValidatorTests.cs
@@ -1,0 +1,186 @@
+using FluentAssertions;
+using IntegratoR.OData.Domain.Settings;
+using Xunit;
+
+namespace IntegratoR.OData.Tests.Domain.Settings;
+
+/// <summary>
+/// Tests for <see cref="ODataSettingsValidator"/>, which fails fast on dangerous or incomplete
+/// <see cref="ODataSettings"/> — an authentication header smuggled into DefaultHeaders, or an
+/// authentication mode missing its required credentials.
+/// </summary>
+public class ODataSettingsValidatorTests
+{
+    private readonly ODataSettingsValidator _sut = new();
+
+    /// <summary>
+    /// A forbidden authentication header in DefaultHeaders must fail validation, compared
+    /// case-insensitively and including a custom configured SubscriptionHeaderKey.
+    /// </summary>
+    [Theory]
+    [InlineData("Authorization", "Ocp-Apim-Subscription-Key")]
+    [InlineData("authorization", "Ocp-Apim-Subscription-Key")]
+    [InlineData("Bearer", "Ocp-Apim-Subscription-Key")]
+    [InlineData("Ocp-Apim-Subscription-Key", "Ocp-Apim-Subscription-Key")]
+    [InlineData("x-my-key", "X-My-Key")]
+    public void Validate_DefaultHeadersContainsForbiddenKey_Fails(string forbiddenHeader, string subscriptionHeaderKey)
+    {
+        // Arrange -- valid ApiKey base config, then poison DefaultHeaders with a forbidden header.
+        var settings = new ODataSettings
+        {
+            Url = "https://test.operations.dynamics.com/data",
+            Authentication = new ODataAuthenticationSettings
+            {
+                Mode = AuthenticationMode.ApiKey,
+                ApiManagement = new ODataApiManagementSettings
+                {
+                    SubscriptionKey = "valid-key",
+                    SubscriptionHeaderKey = subscriptionHeaderKey,
+                    DefaultHeaders = new Dictionary<string, string> { [forbiddenHeader] = "value" }
+                }
+            }
+        };
+
+        // Act
+        var result = _sut.Validate(null, settings);
+
+        // Assert
+        result.Failed.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A benign custom header in DefaultHeaders must pass the forbidden-header rule.
+    /// </summary>
+    [Fact]
+    public void Validate_DefaultHeadersContainsBenignKey_PassesForbiddenHeaderRule()
+    {
+        // Arrange
+        var settings = new ODataSettings
+        {
+            Url = "https://test.operations.dynamics.com/data",
+            Authentication = new ODataAuthenticationSettings
+            {
+                Mode = AuthenticationMode.ApiKey,
+                ApiManagement = new ODataApiManagementSettings
+                {
+                    SubscriptionKey = "valid-key",
+                    SubscriptionHeaderKey = "Ocp-Apim-Subscription-Key",
+                    DefaultHeaders = new Dictionary<string, string> { ["d365foenvironment"] = "UAT" }
+                }
+            }
+        };
+
+        // Act
+        var result = _sut.Validate(null, settings);
+
+        // Assert
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ApiKeyModeWithBlankSubscriptionKey_Fails()
+    {
+        // Arrange
+        var settings = new ODataSettings
+        {
+            Url = "https://test.operations.dynamics.com/data",
+            Authentication = new ODataAuthenticationSettings
+            {
+                Mode = AuthenticationMode.ApiKey,
+                ApiManagement = new ODataApiManagementSettings { SubscriptionKey = string.Empty }
+            }
+        };
+
+        // Act
+        var result = _sut.Validate(null, settings);
+
+        // Assert
+        result.Failed.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// In OAuth mode, each of the four required credentials being blank must fail validation.
+    /// </summary>
+    [Theory]
+    [InlineData("", "secret", "tenant", "https://resource")]
+    [InlineData("client", "", "tenant", "https://resource")]
+    [InlineData("client", "secret", "", "https://resource")]
+    [InlineData("client", "secret", "tenant", "")]
+    public void Validate_OAuthModeWithBlankCredential_Fails(string clientId, string clientSecret, string tenantId, string resource)
+    {
+        // Arrange
+        var settings = new ODataSettings
+        {
+            Url = "https://test.operations.dynamics.com/data",
+            Authentication = new ODataAuthenticationSettings
+            {
+                Mode = AuthenticationMode.OAuth,
+                OAuth = new ODataOAuthSettings
+                {
+                    ClientId = clientId,
+                    ClientSecret = clientSecret,
+                    TenantId = tenantId,
+                    Resource = resource
+                }
+            }
+        };
+
+        // Act
+        var result = _sut.Validate(null, settings);
+
+        // Assert
+        result.Failed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ValidApiKeyConfig_Succeeds()
+    {
+        // Arrange
+        var settings = new ODataSettings
+        {
+            Url = "https://test.operations.dynamics.com/data",
+            Authentication = new ODataAuthenticationSettings
+            {
+                Mode = AuthenticationMode.ApiKey,
+                ApiManagement = new ODataApiManagementSettings
+                {
+                    SubscriptionKey = "valid-subscription-key",
+                    SubscriptionHeaderKey = "Ocp-Apim-Subscription-Key"
+                }
+            }
+        };
+
+        // Act
+        var result = _sut.Validate(null, settings);
+
+        // Assert
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ValidOAuthConfig_Succeeds()
+    {
+        // Arrange
+        var settings = new ODataSettings
+        {
+            Url = "https://test.operations.dynamics.com/data",
+            Authentication = new ODataAuthenticationSettings
+            {
+                Mode = AuthenticationMode.OAuth,
+                OAuth = new ODataOAuthSettings
+                {
+                    ClientId = "client",
+                    ClientSecret = "secret",
+                    TenantId = "tenant",
+                    Resource = "https://resource"
+                }
+            }
+        };
+
+        // Act
+        var result = _sut.Validate(null, settings);
+
+        // Assert
+        result.Succeeded.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
First of a planned 5-PR series fixing the open OData topics + the full architecture-review findings. This PR covers the pipeline behaviours and the auth/security surface.

## Fixes
**Behaviours**
- `LoggingBehaviour`: failure detection `is Result` → `is IResultBase` — **all `Result<T>` failures were silently logged as success** before. `{@Request}` payload moved Information→Debug (PII/secret leak).
- `ValidationBehaviour`: sync `Validate` → `await ValidateAsync(ctx, ct)` (async rules now run, token forwarded); `ConfigureAwait(false)` on success path.
- New shared `ResultFactory.FailFromError<T>` (cached); de-duplicates the reflection in `ValidationBehaviour` and `ODataExceptionHandler`.
- `GetByFilterQueryHandler`: duplicate Information log → Debug.

**Auth / security**
- `ODataAuthenticationHandler`: `ReasonPhrase` → generic `"Authentication failed"` (was leaking the MSAL error); forwards the `CancellationToken`.
- `OAuthAuthenticator`: catches `MsalException` (base) so `MsalClientException` returns `Result.Fail` instead of throwing; reuses the confidential-client app per credential set (secret-**hashed** key, so a rotated secret yields a fresh app); generic error message with MSAL detail on the inner exception only.
- `IAuthenticator`: additive `CancellationToken` overload; old one `[Obsolete]`.
- `ODataExceptionHandler`: 401/403 `IntegrationError` message → generic string.
- New `ODataSettingsValidator` (`IValidateOptions` + `ValidateOnStart`): rejects auth headers in `DefaultHeaders` and incomplete per-mode credentials (also closes the backlog `IValidateOptions` item).

## Verification
- `dotnet build` 0 errors; `dotnet test` **516 passed, 0 failed, 0 skipped** (+24 new tests, un-skips the 3 MSAL OAuth tests).
- Reviewed by `code-reviewer` + `security-reviewer`; both approve-with-changes — all Major/Minor findings addressed (secret-hashed app-cache key, generic MSAL message, `NotSupportedException` guard in `ResultFactory`, `[Obsolete]` version markers, `SubscriptionHeaderKey` guard).

## Semver
`+semver: minor` — additive `ResultFactory`, `ODataSettingsValidator`, `IAuthenticator` overload (+`[Obsolete]`). No removals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)