### PR TITLE
feat(odata): composite-key write bypass + read-path correctness + $orderby (PR-B)

### DIFF
--- a/IntegratoR.OData.FO/Domain/Entities/LedgerJournal/LedgerJournalHeader.cs
+++ b/IntegratoR.OData.FO/Domain/Entities/LedgerJournal/LedgerJournalHeader.cs
@@ -92,6 +92,9 @@ public class LedgerJournalHeader : BaseEntity<string>
     /// </summary>
     public override object[] GetCompositeKey()
     {
-        return [DataAreaId, JournalBatchNumber ?? "null"];
+        // null-forgiving: a null JournalBatchNumber flows through as a real null element (NOT the
+        // literal "null"); ODataService.BuildCompositeKeyObject turns that into a Validation failure.
+        // The ! suppresses CS8601 since the array is object[] but the property is string?.
+        return [DataAreaId, JournalBatchNumber!];
     }
 }

--- a/IntegratoR.OData/Common/Extensions/ApplicationDependencyInjection.cs
+++ b/IntegratoR.OData/Common/Extensions/ApplicationDependencyInjection.cs
@@ -151,11 +151,14 @@ internal static class ApplicationDependencyInjection
             return new ODataClient(options);
         });
 
-        // Register the adapter that wraps PanoramicData's ODataClient
+        // Register the adapter that wraps PanoramicData's ODataClient. The IHttpClientFactory is
+        // passed so the adapter can issue composite-key write requests through the named
+        // "ODataClient" client (carrying auth + Polly + BaseAddress).
         services.AddSingleton<IODataClientAdapter>(serviceProvider =>
         {
             var client = serviceProvider.GetRequiredService<ODataClient>();
-            return new ODataClientAdapter(client);
+            var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+            return new ODataClientAdapter(client, httpClientFactory);
         });
 
         // Register AsyncRetryPolicy for OData operations (in addition to HTTP retries)

--- a/IntegratoR.OData/Common/Filters/IntegratoRODataExpressionTranslator.cs
+++ b/IntegratoR.OData/Common/Filters/IntegratoRODataExpressionTranslator.cs
@@ -80,6 +80,48 @@ internal static class IntegratoRODataExpressionTranslator
     }
 
     /// <summary>
+    /// Converts a strongly-typed order-by specification into an OData <c>$orderby</c> clause,
+    /// honouring <see cref="JsonPropertyNameAttribute"/> on each key selector's member path.
+    /// Emits <c>path</c> for ascending and <c>path desc</c> for descending, joined with <c>, </c>.
+    /// </summary>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when a key selector does not resolve to a member access (e.g. an unsupported
+    /// expression form). Failing fast prevents emitting an invalid <c>$orderby=</c> query
+    /// parameter that the OData server would reject.
+    /// </exception>
+    internal static string ToOrderByString<T>(IReadOnlyList<(Expression<Func<T, object>> KeySelector, bool Descending)> orderBy)
+    {
+        ArgumentNullException.ThrowIfNull(orderBy);
+
+        var clauses = new List<string>(orderBy.Count);
+
+        foreach (var (keySelector, descending) in orderBy)
+        {
+            ArgumentNullException.ThrowIfNull(keySelector);
+
+            // The C# compiler inserts Convert(member, object) around value-type members because
+            // the selector returns object; unwrap it before requiring a MemberExpression.
+            Expression body = keySelector.Body;
+            if (body is UnaryExpression { NodeType: ExpressionType.Convert } convert)
+            {
+                body = convert.Operand;
+            }
+
+            if (body is not MemberExpression member)
+            {
+                throw new NotSupportedException(
+                    $"The order-by expression '{keySelector}' did not resolve to a member access. " +
+                    "Use a property access (x => x.Property).");
+            }
+
+            var path = GetMemberPath(member);
+            clauses.Add(descending ? $"{path} desc" : path);
+        }
+
+        return string.Join(", ", clauses);
+    }
+
+    /// <summary>
     /// Converts a navigation selector expression into an OData <c>$expand</c> clause supporting
     /// nested expand and per-segment <c>$select</c>.
     /// </summary>

--- a/IntegratoR.OData/Common/Services/ODataClientAdapter.cs
+++ b/IntegratoR.OData/Common/Services/ODataClientAdapter.cs
@@ -1,9 +1,13 @@
 using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
 using IntegratoR.Abstractions.Interfaces.Entity;
 using IntegratoR.OData.Common.Filters;
 using IntegratoR.OData.Domain.Models;
 using IntegratoR.OData.Interfaces.Services;
 using PanoramicData.OData.Client;
+using PanoramicData.OData.Client.Exceptions;
 
 namespace IntegratoR.OData.Common.Services;
 
@@ -28,10 +32,30 @@ public class ODataClientAdapter : IODataClientAdapter
         };
 
     private readonly ODataClient _client;
+    private readonly IHttpClientFactory? _httpClientFactory;
 
+    /// <summary>
+    /// Creates an adapter over PanoramicData's <see cref="ODataClient"/> without a named-client
+    /// factory. Composite-key write operations (Update/Delete/BatchUpdate/BatchDelete on an
+    /// <see cref="IDictionary{TKey, TValue}"/> key) are NOT supported through this constructor and
+    /// throw <see cref="InvalidOperationException"/>; production DI always uses the two-argument
+    /// constructor. Retained for guard tests that never issue HTTP traffic.
+    /// </summary>
     public ODataClientAdapter(ODataClient client)
     {
         _client = client;
+    }
+
+    /// <summary>
+    /// Creates an adapter over PanoramicData's <see cref="ODataClient"/> with the named-client
+    /// factory required by the composite-key write bypass. The factory must resolve the
+    /// <c>"ODataClient"</c> named client so raw composite-key requests carry the same
+    /// authentication, Polly resilience, and base address as PanoramicData's own traffic.
+    /// </summary>
+    public ODataClientAdapter(ODataClient client, IHttpClientFactory httpClientFactory)
+    {
+        _client = client;
+        _httpClientFactory = httpClientFactory;
     }
 
     /// <inheritdoc />
@@ -149,6 +173,7 @@ public class ODataClientAdapter : IODataClientAdapter
         Expression<Func<TEntity, bool>>? filter = null,
         Expression<Func<TEntity, object>>? expand = null,
         Expression<Func<TEntity, object>>? select = null,
+        IReadOnlyList<(Expression<Func<TEntity, object>> KeySelector, bool Descending)>? orderBy = null,
         int? skip = null,
         int? top = null,
         CancellationToken cancellationToken = default)
@@ -161,6 +186,7 @@ public class ODataClientAdapter : IODataClientAdapter
         if (filter is not null) query = query.Filter(IntegratoRODataExpressionTranslator.ToFilterString(filter));
         if (expand is not null) query = query.Expand(IntegratoRODataExpressionTranslator.ToExpandString(expand));
         if (select is not null) query = query.Select(IntegratoRODataExpressionTranslator.ToSelectString(select));
+        if (orderBy is not null && orderBy.Count > 0) query = query.OrderBy(IntegratoRODataExpressionTranslator.ToOrderByString(orderBy));
         if (skip.HasValue) query = query.Skip(skip.Value);
         if (top.HasValue) query = query.Top(top.Value);
 
@@ -176,6 +202,15 @@ public class ODataClientAdapter : IODataClientAdapter
         CancellationToken cancellationToken = default)
         where TEntity : class, IEntity
     {
+        // Composite (dictionary) keys cannot be bound by PanoramicData's Key(object) path (it
+        // calls .ToString() on the dict, producing a malformed key) — route them through the
+        // raw-HttpClient bypass. See SendCompositeKeyRequestAsync and FindByKeyAsync's header.
+        if (key is IDictionary<string, object> compositeKey)
+        {
+            return await SendCompositeKeyRequestAsync<TEntity>(
+                HttpMethod.Patch, entitySet, compositeKey, payload, cancellationToken).ConfigureAwait(false);
+        }
+
         if (payload is IDictionary<string, object> dict)
         {
             var jsonResult = await _client.UpdateAsync<object, object>(entitySet, key, dict, null, cancellationToken)
@@ -194,6 +229,15 @@ public class ODataClientAdapter : IODataClientAdapter
         object key,
         CancellationToken cancellationToken = default)
     {
+        // Composite (dictionary) keys bypass PanoramicData's broken Key(object) path; the
+        // throwaway TEntity type parameter is unused for DELETE (no response body deserialised).
+        if (key is IDictionary<string, object> compositeKey)
+        {
+            await SendCompositeKeyRequestAsync<object>(
+                HttpMethod.Delete, entitySet, compositeKey, payload: null, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
         await _client.DeleteAsync(entitySet, key, null, cancellationToken).ConfigureAwait(false);
     }
 
@@ -235,10 +279,31 @@ public class ODataClientAdapter : IODataClientAdapter
         IEnumerable<(object Key, IDictionary<string, object> Payload)> items,
         CancellationToken cancellationToken = default)
     {
+        var itemList = items as IList<(object Key, IDictionary<string, object> Payload)> ?? items.ToList();
+
+        // A batch is homogeneous for a given TEntity: ODataService.BuildBatchKeys yields all-scalar
+        // keys for single-key entities or all-dictionary keys for composite entities, never mixed.
+        // D365 F&O entities are all composite-keyed and cannot use PanoramicData's atomic changeset
+        // (it cannot bind a dictionary key), so when any key is a dictionary, send EVERY item as an
+        // individual HTTP request preserving index order; otherwise keep the atomic changeset path.
+        if (itemList.Any(item => item.Key is IDictionary<string, object>))
+        {
+            return await SendCompositeKeyBatchAsync(
+                itemList.Count,
+                async (index, ct) =>
+                {
+                    // isComposite invariant (the homogeneity above) guarantees this cast is safe.
+                    var (key, payload) = itemList[index];
+                    return await SendCompositeKeyRequestRawAsync(
+                        HttpMethod.Patch, entitySet, (IDictionary<string, object>)key, payload, ct).ConfigureAwait(false);
+                },
+                cancellationToken).ConfigureAwait(false);
+        }
+
         var batch = _client.CreateBatch();
         batch.Changeset(changeset =>
         {
-            foreach (var (key, payload) in items)
+            foreach (var (key, payload) in itemList)
             {
                 changeset.Update<object, object>(entitySet, key, payload);
             }
@@ -253,16 +318,202 @@ public class ODataClientAdapter : IODataClientAdapter
         IEnumerable<object> keys,
         CancellationToken cancellationToken = default)
     {
+        var keyList = keys as IList<object> ?? keys.ToList();
+
+        // Homogeneous-batch invariant (see BatchUpdateAsync): a composite-keyed entity yields all
+        // dictionary keys, so when any key is a dictionary, send EVERY item as an individual HTTP
+        // request preserving index order; otherwise keep the atomic changeset path.
+        if (keyList.Any(key => key is IDictionary<string, object>))
+        {
+            return await SendCompositeKeyBatchAsync(
+                keyList.Count,
+                // isComposite invariant guarantees keyList[index] is an IDictionary here.
+                async (index, ct) => await SendCompositeKeyRequestRawAsync(
+                    HttpMethod.Delete, entitySet, (IDictionary<string, object>)keyList[index], payload: null, ct).ConfigureAwait(false),
+                cancellationToken).ConfigureAwait(false);
+        }
+
         var batch = _client.CreateBatch();
         batch.Changeset(changeset =>
         {
-            foreach (var key in keys)
+            foreach (var key in keyList)
             {
                 changeset.Delete(entitySet, key);
             }
         });
         ODataBatchResponse response = await batch.ExecuteAsync(cancellationToken).ConfigureAwait(false);
         return MapBatchResponse(response);
+    }
+
+    /// <summary>
+    /// Issues a single composite-key write (PATCH/DELETE) through the named <c>"ODataClient"</c>
+    /// HttpClient (which carries auth + Polly + BaseAddress), bypassing PanoramicData's broken
+    /// <c>Key(object)</c> dictionary path. On success a PATCH body is deserialised to
+    /// <typeparamref name="TEntity"/>; on a non-success status the matching PanoramicData
+    /// exception is thrown so the existing <c>ODataExceptionHandler</c> maps it (404 →
+    /// <see cref="ODataNotFoundException"/>; otherwise <see cref="ODataClientException"/> carrying
+    /// status, body, and URL).
+    /// </summary>
+    private async Task<TEntity> SendCompositeKeyRequestAsync<TEntity>(
+        HttpMethod method,
+        string entitySet,
+        IDictionary<string, object> key,
+        object? payload,
+        CancellationToken cancellationToken)
+        where TEntity : class
+    {
+        (HttpStatusCode statusCode, string? body, string requestUrl) =
+            await SendCompositeKeyRequestRawAsync(method, entitySet, key, payload, cancellationToken).ConfigureAwait(false);
+
+        if ((int)statusCode is < 200 or > 299)
+        {
+            throw CreateMappableException((int)statusCode, body, requestUrl);
+        }
+
+        // DELETE has no usable response body; callers discard the returned value.
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return null!;
+        }
+
+        return System.Text.Json.JsonSerializer.Deserialize<TEntity>(body, CaseInsensitiveOptions)
+            ?? throw new InvalidOperationException(
+                $"Failed to deserialize OData response to {typeof(TEntity).Name}. Response body was null or incompatible.");
+    }
+
+    /// <summary>
+    /// Issues a single composite-key write and returns the raw outcome (status, body, URL) WITHOUT
+    /// throwing — used by the batch path so per-item failures are collected rather than aborting
+    /// the whole batch. Validates each key field name and the dictionary is non-empty, mirroring
+    /// <see cref="FindByKeyAsync{TEntity}"/>.
+    /// </summary>
+    private async Task<(HttpStatusCode StatusCode, string? Body, string RequestUrl)> SendCompositeKeyRequestRawAsync(
+        HttpMethod method,
+        string entitySet,
+        IDictionary<string, object> key,
+        object? payload,
+        CancellationToken cancellationToken)
+    {
+        if (_httpClientFactory is null)
+        {
+            throw new InvalidOperationException(
+                "Composite-key write operations require the IHttpClientFactory-based constructor of " +
+                "ODataClientAdapter. Production DI uses the two-argument constructor; the single-argument " +
+                "constructor is for guard tests that never issue HTTP traffic.");
+        }
+
+        // requestUrl is a NON-ROOTED relative URI ("EntitySet(...)", no leading '/'). It is resolved
+        // against the named client's HttpClient.BaseAddress, which ApplicationDependencyInjection
+        // always sets via NormaliseBaseUrl (url.TrimEnd('/') + "/"), i.e. it ALWAYS ends with '/'.
+        // That trailing slash is what makes a non-rooted relative compose correctly and PRESERVE the
+        // base path segment (e.g. "https://host/fo/" + "LedgerJournalHeaders(...)" =>
+        // "https://host/fo/LedgerJournalHeaders(...)"). Without it, Uri composition would drop "/fo".
+        string requestUrl = BuildCompositeKeyUrl(entitySet, key);
+
+        using var request = new HttpRequestMessage(method, requestUrl);
+        if (payload is not null && method != HttpMethod.Delete)
+        {
+            string json = System.Text.Json.JsonSerializer.Serialize(payload, CaseInsensitiveOptions);
+            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        }
+
+        HttpClient client = _httpClientFactory.CreateClient("ODataClient");
+        using HttpResponseMessage response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        string? body = response.Content is null
+            ? null
+            : await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        return (response.StatusCode, body, requestUrl);
+    }
+
+    /// <summary>
+    /// Issues every item of a composite-keyed batch as an individual HTTP request (composite-keyed
+    /// entities cannot use PanoramicData's atomic changeset), assembling a per-item
+    /// <see cref="BatchOperationResult"/> in original index order so the existing
+    /// <c>MapBatchResponse</c>/<c>BuildBatchErrors</c> contract is preserved. Per-item failures are
+    /// collected, never thrown — so a partial failure surfaces as failed indices, not an exception.
+    /// </summary>
+    private static async Task<IReadOnlyList<BatchOperationResult>> SendCompositeKeyBatchAsync(
+        int count,
+        Func<int, CancellationToken, Task<(HttpStatusCode StatusCode, string? Body, string RequestUrl)>> sendComposite,
+        CancellationToken cancellationToken)
+    {
+        var results = new List<BatchOperationResult>(count);
+
+        for (int i = 0; i < count; i++)
+        {
+            (HttpStatusCode statusCode, string? body, _) =
+                await sendComposite(i, cancellationToken).ConfigureAwait(false);
+
+            int code = (int)statusCode;
+            bool isSuccess = code is >= 200 and <= 299;
+            results.Add(new BatchOperationResult
+            {
+                Index = i,
+                StatusCode = code,
+                IsSuccess = isSuccess,
+                ErrorMessage = isSuccess ? null : $"HTTP {code}",
+                ResponseBody = body
+            });
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Builds the keyed URL segment <c>EntitySet(field=literal,…)</c> for a composite key, reusing
+    /// the same OData v4 literal formatter (<see cref="IntegratoRODataExpressionTranslator.FormatValue"/>)
+    /// as the filter/read path. Validates each field name and rejects empty dictionaries, mirroring
+    /// <see cref="FindByKeyAsync{TEntity}"/>.
+    /// </summary>
+    private static string BuildCompositeKeyUrl(string entitySet, IDictionary<string, object> key)
+    {
+        if (key.Count == 0)
+        {
+            throw new ArgumentException(
+                "Composite key dictionary must contain at least one key field. " +
+                "An empty dictionary would emit a keyless URL segment.",
+                nameof(key));
+        }
+
+        foreach (KeyValuePair<string, object> kv in key)
+        {
+            if (!IsValidODataFieldName(kv.Key))
+            {
+                throw new ArgumentException(
+                    $"Composite key field name '{kv.Key}' is not a valid OData property identifier. " +
+                    "Keys must match the pattern ^[A-Za-z_][A-Za-z0-9_.]*$ and come from entity " +
+                    "reflection (attribute-derived wire names), not user input.",
+                    nameof(key));
+            }
+        }
+
+        string segments = string.Join(
+            ",",
+            key.Select(kv => $"{kv.Key}={IntegratoRODataExpressionTranslator.FormatValue(kv.Value)}"));
+
+        return $"{entitySet}({segments})";
+    }
+
+    /// <summary>
+    /// Maps a non-success composite-key write response to the PanoramicData exception the existing
+    /// <c>ODataExceptionHandler</c> expects: 404 → <see cref="ODataNotFoundException"/>; any other
+    /// non-2xx → <see cref="ODataClientException"/> carrying status, body, and request URL.
+    /// </summary>
+    private static ODataClientException CreateMappableException(int statusCode, string? responseBody, string requestUrl)
+    {
+        if (statusCode == 404)
+        {
+            return new ODataNotFoundException(
+                $"Entity at '{requestUrl}' was not found (HTTP 404).", requestUrl);
+        }
+
+        return new ODataClientException(
+            $"OData request to '{requestUrl}' failed with HTTP {statusCode}.",
+            statusCode,
+            responseBody,
+            requestUrl);
     }
 
     /// <summary>

--- a/IntegratoR.OData/Common/Services/ODataService.cs
+++ b/IntegratoR.OData/Common/Services/ODataService.cs
@@ -98,14 +98,20 @@ public class ODataService<TEntity> : IODataService<TEntity>, IODataBatchService<
                 ErrorType.Validation)));
         }
 
+        var keyResult = BuildCompositeKeyObject(keyValues);
+        if (keyResult.IsFailed)
+        {
+            return Task.FromResult(Result.Fail<TEntity>(keyResult.Errors));
+        }
+
+        var key = keyResult.Value;
+
         return _exceptionHandler.ExecuteAsync(
             operationName: "GetByKey",
             operation: async () =>
             {
                 _logger.LogDebug("Retrieving {EntityType} by key: {@KeyValues}",
                     typeof(TEntity).Name, keyValues);
-
-                var key = BuildCompositeKeyObject(keyValues);
 
                 var entity = await _client
                     .FindByKeyAsync<TEntity>(_entitySetName, key, cancellationToken)
@@ -134,6 +140,14 @@ public class ODataService<TEntity> : IODataService<TEntity>, IODataBatchService<
                 ErrorType.Validation)));
         }
 
+        var keyResult = BuildCompositeKeyObject(entity.GetCompositeKey());
+        if (keyResult.IsFailed)
+        {
+            return Task.FromResult(Result.Fail<TEntity>(keyResult.Errors));
+        }
+
+        var key = keyResult.Value;
+
         return _exceptionHandler.ExecuteAsync(
             operationName: "Update",
             operation: async () =>
@@ -141,7 +155,6 @@ public class ODataService<TEntity> : IODataService<TEntity>, IODataBatchService<
                 _logger.LogDebug("Updating {EntityType} with key {@Key}",
                     typeof(TEntity).Name, entity.GetCompositeKey());
 
-                var key = BuildCompositeKeyObject(entity.GetCompositeKey());
                 var payload = CreatePayload(entity, isCreateOperation: false);
 
                 return await _client
@@ -163,14 +176,20 @@ public class ODataService<TEntity> : IODataService<TEntity>, IODataBatchService<
                 ErrorType.Validation)));
         }
 
+        var keyResult = BuildCompositeKeyObject(entity.GetCompositeKey());
+        if (keyResult.IsFailed)
+        {
+            return Task.FromResult(Result.Fail(keyResult.Errors));
+        }
+
+        var key = keyResult.Value;
+
         return _exceptionHandler.ExecuteNonQueryAsync(
             operationName: "Delete",
             operation: async () =>
             {
                 _logger.LogDebug("Deleting {EntityType} with key {@Key}",
                     typeof(TEntity).Name, entity.GetCompositeKey());
-
-                var key = BuildCompositeKeyObject(entity.GetCompositeKey());
 
                 await _client
                     .DeleteAsync(_entitySetName, key, cancellationToken)
@@ -186,6 +205,7 @@ public class ODataService<TEntity> : IODataService<TEntity>, IODataBatchService<
     #region IODataService Implementation
 
     /// <inheritdoc />
+    [Obsolete("Since v1.4.0; the Func-based orderBy was never applied to the OData query (it was silently dropped). Use the overload taking IReadOnlyList<(Expression<Func<TEntity, object>> KeySelector, bool Descending)> orderBy.")]
     public Task<Result<IEnumerable<TEntity>>> QueryAsync(
         Expression<Func<TEntity, bool>>? filter = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
@@ -195,10 +215,30 @@ public class ODataService<TEntity> : IODataService<TEntity>, IODataBatchService<
         int? top = null,
         CancellationToken cancellationToken = default)
     {
+        // orderBy is intentionally NOT forwarded — the Func-based shape cannot be translated to an
+        // OData $orderby clause and was always silently dropped. Use the typed overload below.
         return _exceptionHandler.ExecuteCollectionAsync(
             operationName: "Query",
             operation: async () => await _client
-                .FindEntriesAsync<TEntity>(_entitySetName, filter, expand, select, skip, top, cancellationToken)
+                .FindEntriesAsync<TEntity>(_entitySetName, filter, expand, select, orderBy: null, skip, top, cancellationToken)
+                .ConfigureAwait(false),
+            cancellationToken: cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IEnumerable<TEntity>>> QueryAsync(
+        Expression<Func<TEntity, bool>>? filter,
+        IReadOnlyList<(Expression<Func<TEntity, object>> KeySelector, bool Descending)>? orderBy,
+        Expression<Func<TEntity, object>>? expand = null,
+        Expression<Func<TEntity, object>>? select = null,
+        int? skip = null,
+        int? top = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _exceptionHandler.ExecuteCollectionAsync(
+            operationName: "Query",
+            operation: async () => await _client
+                .FindEntriesAsync<TEntity>(_entitySetName, filter, expand, select, orderBy, skip, top, cancellationToken)
                 .ConfigureAwait(false),
             cancellationToken: cancellationToken);
     }
@@ -259,11 +299,18 @@ public class ODataService<TEntity> : IODataService<TEntity>, IODataBatchService<
     {
         var entityList = entities as IList<TEntity> ?? entities.ToList();
 
+        var keysResult = BuildBatchKeys(entityList);
+        if (keysResult.IsFailed)
+        {
+            return Task.FromResult(Result.Fail(keysResult.Errors));
+        }
+
+        var keys = keysResult.Value;
+
         return _exceptionHandler.ExecuteNonQueryAsync(
             operationName: "DeleteBatch",
             operation: async () =>
             {
-                var keys = entityList.Select(e => BuildCompositeKeyObject(e.GetCompositeKey()));
                 IReadOnlyList<BatchOperationResult> results = await _client
                     .BatchDeleteAsync(_entitySetName, keys, cancellationToken)
                     .ConfigureAwait(false);
@@ -280,12 +327,20 @@ public class ODataService<TEntity> : IODataService<TEntity>, IODataBatchService<
     {
         var entityList = entities as IList<TEntity> ?? entities.ToList();
 
+        var keysResult = BuildBatchKeys(entityList);
+        if (keysResult.IsFailed)
+        {
+            return Task.FromResult(Result.Fail(keysResult.Errors));
+        }
+
+        var items = entityList
+            .Select((e, i) => (keysResult.Value[i], (IDictionary<string, object>)CreatePayload(e, isCreateOperation: false)))
+            .ToList();
+
         return _exceptionHandler.ExecuteNonQueryAsync(
             operationName: "UpdateBatch",
             operation: async () =>
             {
-                var items = entityList.Select(e =>
-                    (BuildCompositeKeyObject(e.GetCompositeKey()), (IDictionary<string, object>)CreatePayload(e, isCreateOperation: false)));
                 IReadOnlyList<BatchOperationResult> results = await _client
                     .BatchUpdateAsync(_entitySetName, items, cancellationToken)
                     .ConfigureAwait(false);
@@ -314,36 +369,80 @@ public class ODataService<TEntity> : IODataService<TEntity>, IODataBatchService<
 
     /// <summary>
     /// Builds a composite key object from key values by mapping them to key property names.
-    /// For single keys, returns the value directly. For composite keys, returns a dictionary.
+    /// For single keys, returns the value directly. For composite keys, returns a dictionary of
+    /// <c>wireName → value</c>. Returns a <see cref="ErrorType.Validation"/> failure when the
+    /// supplied value count does not match the number of <c>[Key]</c> properties, or when any key
+    /// element is null (a null key cannot identify an entity).
     /// </summary>
-    private object BuildCompositeKeyObject(object[] keyValues)
+    private static Result<object> BuildCompositeKeyObject(object[] keyValues)
     {
         if (keyValues.Length == 1)
         {
-            return keyValues[0];
+            if (keyValues[0] is null)
+            {
+                return Result.Fail<object>(new IntegrationError(
+                    $"{typeof(TEntity).Name}.InvalidKey",
+                    "The single key value was null; a null key cannot identify an entity.",
+                    ErrorType.Validation));
+            }
+
+            return Result.Ok(keyValues[0]);
         }
 
+        // GetProperties() order is undefined, so sort by MetadataToken (declaration order within
+        // the type) to keep each [Key] property zipped to its corresponding value deterministically.
         var keyProperties = KeyPropertyCache.GetOrAdd(typeof(TEntity), type =>
             type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
                 .Where(p => p.GetCustomAttribute<System.ComponentModel.DataAnnotations.KeyAttribute>() is not null)
+                .OrderBy(p => p.MetadataToken)
                 .ToArray());
 
-        if (keyProperties.Length == keyValues.Length)
+        if (keyProperties.Length != keyValues.Length)
         {
-            var keyDict = new Dictionary<string, object>();
-            for (var i = 0; i < keyProperties.Length; i++)
-            {
-                keyDict[PropertyNameResolver.Resolve(keyProperties[i])] = keyValues[i];
-            }
-            return keyDict;
+            return Result.Fail<object>(new IntegrationError(
+                $"{typeof(TEntity).Name}.KeyCountMismatch",
+                $"Expected {keyProperties.Length} key properties but received {keyValues.Length} values. " +
+                $"Check [Key] attributes on {typeof(TEntity).Name}.",
+                ErrorType.Validation));
         }
 
-        // Fallback: return first value if key property count doesn't match
-        _logger.LogWarning(
-            "Key property count mismatch for {EntityType}: expected {Expected} key properties but received {Actual} values. " +
-            "Falling back to first key value. Check [Key] attributes on the entity.",
-            typeof(TEntity).Name, keyProperties.Length, keyValues.Length);
-        return keyValues[0];
+        var keyDict = new Dictionary<string, object>();
+        for (var i = 0; i < keyProperties.Length; i++)
+        {
+            var name = PropertyNameResolver.Resolve(keyProperties[i]);
+            if (keyValues[i] is null)
+            {
+                return Result.Fail<object>(new IntegrationError(
+                    $"{typeof(TEntity).Name}.InvalidKey",
+                    $"Composite key element at index {i} for field '{name}' was null; a null key cannot identify an entity.",
+                    ErrorType.Validation));
+            }
+
+            keyDict[name] = keyValues[i];
+        }
+
+        return Result.Ok<object>(keyDict);
+    }
+
+    /// <summary>
+    /// Builds the composite key object for every entity in a batch, short-circuiting on the first
+    /// <see cref="ErrorType.Validation"/> failure so a bad key is surfaced before any HTTP traffic.
+    /// </summary>
+    private static Result<List<object>> BuildBatchKeys(IList<TEntity> entities)
+    {
+        var keys = new List<object>(entities.Count);
+        foreach (var entity in entities)
+        {
+            var keyResult = BuildCompositeKeyObject(entity.GetCompositeKey());
+            if (keyResult.IsFailed)
+            {
+                return Result.Fail<List<object>>(keyResult.Errors);
+            }
+
+            keys.Add(keyResult.Value);
+        }
+
+        return Result.Ok(keys);
     }
 
     private static Dictionary<string, object> CreatePayload(TEntity entity, bool isCreateOperation)

--- a/IntegratoR.OData/Interfaces/Services/IODataClientAdapter.cs
+++ b/IntegratoR.OData/Interfaces/Services/IODataClientAdapter.cs
@@ -42,13 +42,19 @@ public interface IODataClientAdapter
         where TEntity : class, IEntity;
 
     /// <summary>
-    /// Queries entities with optional filter, expand, select, skip, and top parameters.
+    /// Queries entities with optional filter, expand, select, order-by, skip, and top parameters.
     /// </summary>
+    /// <param name="orderBy">
+    /// Optional ordered list of <c>(keySelector, descending)</c> tuples translated into an OData
+    /// <c>$orderby</c> clause. Each key selector honours <c>[JsonPropertyName]</c> on the member
+    /// path, so D365 camelCase wire names (e.g. <c>dataAreaId</c>) sort correctly.
+    /// </param>
     Task<IEnumerable<TEntity>> FindEntriesAsync<TEntity>(
         string entitySet,
         Expression<Func<TEntity, bool>>? filter = null,
         Expression<Func<TEntity, object>>? expand = null,
         Expression<Func<TEntity, object>>? select = null,
+        IReadOnlyList<(Expression<Func<TEntity, object>> KeySelector, bool Descending)>? orderBy = null,
         int? skip = null,
         int? top = null,
         CancellationToken cancellationToken = default)
@@ -58,6 +64,18 @@ public interface IODataClientAdapter
     /// Updates an existing entity via OData PATCH.
     /// The payload can be a <typeparamref name="TEntity"/> instance or an <see cref="IDictionary{TKey, TValue}"/> for partial payloads.
     /// </summary>
+    /// <param name="entitySet">The OData entity set name.</param>
+    /// <param name="key">
+    /// Either a scalar key value (for single-key entities) or an
+    /// <see cref="IDictionary{TKey, TValue}"/> of <c>wireName → value</c> pairs for composite
+    /// keys. Composite (dictionary) keys are routed through a raw-HttpClient bypass that PATCHes
+    /// the keyed URL <c>EntitySet(field=literal,…)</c>, because PanoramicData's <c>Key(object)</c>
+    /// path cannot bind a dictionary. Each dictionary key must be the <b>OData wire name</b>
+    /// (what appears in a <c>$filter</c>), obtained from entity reflection via
+    /// <c>PropertyNameResolver</c>, and must match <c>^[A-Za-z_][A-Za-z0-9_.]*$</c>.
+    /// </param>
+    /// <param name="payload">The PATCH payload (entity instance or partial dictionary).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     Task<TEntity> UpdateAsync<TEntity>(
         string entitySet,
         object key,
@@ -68,6 +86,17 @@ public interface IODataClientAdapter
     /// <summary>
     /// Deletes an entity by key via OData DELETE.
     /// </summary>
+    /// <param name="entitySet">The OData entity set name.</param>
+    /// <param name="key">
+    /// Either a scalar key value (for single-key entities) or an
+    /// <see cref="IDictionary{TKey, TValue}"/> of <c>wireName → value</c> pairs for composite
+    /// keys. Composite (dictionary) keys are routed through a raw-HttpClient bypass that DELETEs
+    /// the keyed URL <c>EntitySet(field=literal,…)</c>, because PanoramicData's <c>Key(object)</c>
+    /// path cannot bind a dictionary. Each dictionary key must be the <b>OData wire name</b>
+    /// (what appears in a <c>$filter</c>), obtained from entity reflection via
+    /// <c>PropertyNameResolver</c>, and must match <c>^[A-Za-z_][A-Za-z0-9_.]*$</c>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     Task DeleteAsync(
         string entitySet,
         object key,

--- a/IntegratoR.OData/Interfaces/Services/IODataService.cs
+++ b/IntegratoR.OData/Interfaces/Services/IODataService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq.Expressions;
 using FluentResults;
 using IntegratoR.Abstractions.Interfaces.Entity;
@@ -33,9 +34,36 @@ public interface IODataService<TEntity> : IService<TEntity> where TEntity : IEnt
     /// <param name="top">The maximum number of entities to return. Corresponds to the OData `$top` query option.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A <see cref="Result{T}"/> containing a collection of entities that match the specified criteria.</returns>
+    [Obsolete("Since v1.4.0; the Func-based orderBy was never applied to the OData query (it was silently dropped). Use the overload taking IReadOnlyList<(Expression<Func<TEntity, object>> KeySelector, bool Descending)> orderBy.")]
     Task<Result<IEnumerable<TEntity>>> QueryAsync(
         Expression<Func<TEntity, bool>>? filter = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
+        Expression<Func<TEntity, object>>? expand = null,
+        Expression<Func<TEntity, object>>? select = null,
+        int? skip = null,
+        int? top = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously retrieves a collection of entities using a comprehensive set of OData query
+    /// options, including a strongly-typed <c>$orderby</c> specification that honours
+    /// <c>[JsonPropertyName]</c> on each key selector.
+    /// </summary>
+    /// <param name="filter">A LINQ expression to filter the entities. Corresponds to the OData `$filter` query option.</param>
+    /// <param name="orderBy">
+    /// An ordered list of <c>(keySelector, descending)</c> tuples specifying the sort order.
+    /// Corresponds to the OData `$orderby` query option. Each key selector's member path honours
+    /// <c>[JsonPropertyName]</c>, so D365 camelCase wire names sort correctly.
+    /// </param>
+    /// <param name="expand">A LINQ expression to include related entities (navigation properties). Corresponds to the OData `$expand` query option.</param>
+    /// <param name="select">A LINQ expression to select a subset of properties. Corresponds to the OData `$select` query option.</param>
+    /// <param name="skip">The number of entities to skip for paging. Corresponds to the OData `$skip` query option.</param>
+    /// <param name="top">The maximum number of entities to return. Corresponds to the OData `$top` query option.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A <see cref="Result{T}"/> containing a collection of entities that match the specified criteria.</returns>
+    Task<Result<IEnumerable<TEntity>>> QueryAsync(
+        Expression<Func<TEntity, bool>>? filter,
+        IReadOnlyList<(Expression<Func<TEntity, object>> KeySelector, bool Descending)>? orderBy,
         Expression<Func<TEntity, object>>? expand = null,
         Expression<Func<TEntity, object>>? select = null,
         int? skip = null,

--- a/tests/IntegratoR.OData.FO.Tests/Domain/Entities/LedgerJournal/LedgerJournalHeaderTests.cs
+++ b/tests/IntegratoR.OData.FO.Tests/Domain/Entities/LedgerJournal/LedgerJournalHeaderTests.cs
@@ -32,10 +32,13 @@ public class LedgerJournalHeaderTests
     }
 
     /// <summary>
-    /// Verifies that GetCompositeKey returns the string literal "null" when JournalBatchNumber is null.
+    /// Verifies that GetCompositeKey returns a real null element (not the literal string "null")
+    /// when JournalBatchNumber is null. A header without a batch number has no identity yet;
+    /// <see cref="IntegratoR.OData.Common.Services.ODataService{TEntity}"/> turns the null element
+    /// into a Validation failure rather than writing against a non-existent batch named "null".
     /// </summary>
     [Fact]
-    public void GetCompositeKey_NullJournalBatchNumber_ReturnsNullStringLiteral()
+    public void GetCompositeKey_NullJournalBatchNumber_ReturnsNullElementNotLiteralString()
     {
         // Arrange
         var header = new LedgerJournalHeader
@@ -51,7 +54,8 @@ public class LedgerJournalHeaderTests
 
         // Assert
         key.Should().HaveCount(2);
-        key[1].Should().Be("null");
+        key[1].Should().BeNull();
+        key[1].Should().NotBe("null");
     }
 
     /// <summary>

--- a/tests/IntegratoR.OData.Tests/Common/Filters/IntegratoRODataExpressionTranslatorTests.cs
+++ b/tests/IntegratoR.OData.Tests/Common/Filters/IntegratoRODataExpressionTranslatorTests.cs
@@ -681,4 +681,55 @@ public sealed class IntegratoRODataExpressionTranslatorTests
         second.Should().Be(first);
         third.Should().Be(first);
     }
+
+    /// <summary>
+    /// Single ascending key on a [JsonPropertyName("dataAreaId")] property must emit the camelCase
+    /// wire name (proving [JsonPropertyName] is honoured), with no <c>desc</c> suffix.
+    /// </summary>
+    [Fact]
+    public void ToOrderByString_SingleAscending_HonoursJsonPropertyName()
+    {
+        var orderBy = new (Expression<Func<JournalEntity, object>>, bool)[]
+        {
+            (x => x.DataAreaId, false)
+        };
+
+        var result = IntegratoRODataExpressionTranslator.ToOrderByString(orderBy);
+
+        result.Should().Be("dataAreaId");
+    }
+
+    /// <summary>
+    /// A descending key emits the <c>desc</c> suffix after the resolved wire name.
+    /// </summary>
+    [Fact]
+    public void ToOrderByString_SingleDescending_EmitsDescSuffix()
+    {
+        var orderBy = new (Expression<Func<JournalEntity, object>>, bool)[]
+        {
+            (x => x.DataAreaId, true)
+        };
+
+        var result = IntegratoRODataExpressionTranslator.ToOrderByString(orderBy);
+
+        result.Should().Be("dataAreaId desc");
+    }
+
+    /// <summary>
+    /// Multiple keys join with ", " and each honours its own wire-name resolution and direction:
+    /// the camelCase [JsonPropertyName] field ascending, followed by a PascalCase field descending.
+    /// </summary>
+    [Fact]
+    public void ToOrderByString_MultiKey_JoinsAndHonoursDirectionAndJsonPropertyName()
+    {
+        var orderBy = new (Expression<Func<JournalEntity, object>>, bool)[]
+        {
+            (x => x.DataAreaId, false),
+            (x => x.JournalBatchNumber, true)
+        };
+
+        var result = IntegratoRODataExpressionTranslator.ToOrderByString(orderBy);
+
+        result.Should().Be("dataAreaId, JournalBatchNumber desc");
+    }
 }

--- a/tests/IntegratoR.OData.Tests/Common/Services/ODataClientAdapterCompositeKeyWriteTests.cs
+++ b/tests/IntegratoR.OData.Tests/Common/Services/ODataClientAdapterCompositeKeyWriteTests.cs
@@ -1,0 +1,324 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using IntegratoR.Abstractions.Domain.Entities;
+using IntegratoR.Abstractions.Interfaces.Authentication;
+using IntegratoR.OData.Common.Extensions;
+using IntegratoR.OData.Common.Services;
+using IntegratoR.OData.Domain.Settings;
+using IntegratoR.OData.Interfaces.Services;
+using IntegratoR.TestKit.Fakes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using PanoramicData.OData.Client;
+using PanoramicData.OData.Client.Exceptions;
+using Xunit;
+
+namespace IntegratoR.OData.Tests.Common.Services;
+
+/// <summary>
+/// Pins the composite-key WRITE bypass in <see cref="ODataClientAdapter"/>: D365 F&O composite
+/// (dictionary) keys cannot be bound by PanoramicData's <c>Key(object)</c> path, so Update/Delete
+/// and the batch variants issue raw HTTP requests through the named <c>"ODataClient"</c> client
+/// (carrying auth + Polly + BaseAddress). These tests wire a <see cref="FakeHttpMessageHandler"/>
+/// as that client's primary handler — the same pattern as
+/// <c>AddODataClient_PreservesPathSegment_WhenComposingRelativeRequestUri</c>.
+/// </summary>
+public sealed class ODataClientAdapterCompositeKeyWriteTests : IDisposable
+{
+    private const string BaseUrl = "https://lbbw-im-api-management.azure-api.net/fo";
+    private const string EntitySet = "TestJournalHeaders";
+
+    // Every provider built by BuildHarness is tracked here and disposed in Dispose() so the named
+    // HttpClient/IHttpClientFactory and ILogger they hold are not leaked across tests.
+    private readonly List<ServiceProvider> _providers = new();
+
+    private (ServiceProvider Provider, FakeHttpMessageHandler Handler) BuildHarness()
+    {
+        var fakeHandler = new FakeHttpMessageHandler();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IAuthenticator>(Substitute.For<IAuthenticator>());
+        services.AddODataClient(options =>
+        {
+            options.Url = BaseUrl;
+            options.Authentication.Mode = AuthenticationMode.ApiKey;
+            options.Authentication.ApiManagement.SubscriptionKey = "test-key";
+            options.Authentication.ApiManagement.SubscriptionHeaderKey = "Ocp-Apim-Subscription-Key";
+            options.Resilience.EnableRetries = false;
+            options.Resilience.UseCircuitBreaker = false;
+        });
+
+        // Plug the fake as the terminal primary handler for the named client so composite-key
+        // writes flow: ODataAuthenticationHandler -> Polly (no-op) -> FakeHttpMessageHandler.
+        services.AddHttpClient("ODataClient").ConfigurePrimaryHttpMessageHandler(() => fakeHandler);
+
+        var provider = services.BuildServiceProvider();
+        _providers.Add(provider);
+        return (provider, fakeHandler);
+    }
+
+    private static ODataClientAdapter ResolveAdapter(ServiceProvider provider)
+    {
+        var client = provider.GetRequiredService<ODataClient>();
+        var factory = provider.GetRequiredService<IHttpClientFactory>();
+        return new ODataClientAdapter(client, factory);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        foreach (var provider in _providers)
+        {
+            provider.Dispose();
+        }
+
+        _providers.Clear();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_CompositeKey_EmitsPatchToKeyedUrlWithSerialisedBody()
+    {
+        // Arrange
+        var (provider, handler) = BuildHarness();
+        handler.Queue(HttpStatusCode.OK, "{\"dataAreaId\":\"1210\",\"JournalBatchNumber\":\"LNR0000266\",\"Description\":\"Updated\"}");
+        var adapter = ResolveAdapter(provider);
+
+        var key = new Dictionary<string, object>
+        {
+            ["dataAreaId"] = "1210",
+            ["JournalBatchNumber"] = "LNR0000266"
+        };
+        var payload = new Dictionary<string, object> { ["Description"] = "Updated" };
+
+        // Act
+        var result = await adapter.UpdateAsync<TestJournalHeader>(EntitySet, key, payload, CancellationToken.None);
+
+        // Assert
+        handler.SentRequests.Should().HaveCount(1);
+        handler.SentRequests[0].Method.Should().Be(HttpMethod.Patch);
+        handler.SentRequests[0].RequestUri!.AbsoluteUri
+            .Should().Be($"{BaseUrl}/{EntitySet}(dataAreaId='1210',JournalBatchNumber='LNR0000266')");
+
+        var sentBody = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(handler.SentRequestBodies[0]!);
+        sentBody!.Should().ContainKey("Description");
+        sentBody["Description"].GetString().Should().Be("Updated");
+
+        result.Description.Should().Be("Updated");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_CompositeKey_EmitsDeleteToKeyedUrlWithNoBody()
+    {
+        // Arrange
+        var (provider, handler) = BuildHarness();
+        handler.Queue(HttpStatusCode.NoContent);
+        var adapter = ResolveAdapter(provider);
+
+        var key = new Dictionary<string, object>
+        {
+            ["dataAreaId"] = "1210",
+            ["JournalBatchNumber"] = "LNR0000266"
+        };
+
+        // Act
+        await adapter.DeleteAsync(EntitySet, key, CancellationToken.None);
+
+        // Assert
+        handler.SentRequests.Should().HaveCount(1);
+        handler.SentRequests[0].Method.Should().Be(HttpMethod.Delete);
+        handler.SentRequests[0].RequestUri!.AbsoluteUri
+            .Should().Be($"{BaseUrl}/{EntitySet}(dataAreaId='1210',JournalBatchNumber='LNR0000266')");
+        handler.SentRequestBodies[0].Should().BeNull();
+    }
+
+    [Fact]
+    public async Task BatchUpdate_CompositeKeys_EmitPerItemKeyedUrls()
+    {
+        // Arrange
+        var (provider, handler) = BuildHarness();
+        handler.Queue(HttpStatusCode.OK, "{}");
+        handler.Queue(HttpStatusCode.OK, "{}");
+        var adapter = ResolveAdapter(provider);
+
+        var items = new List<(object Key, IDictionary<string, object> Payload)>
+        {
+            (new Dictionary<string, object> { ["dataAreaId"] = "1210", ["JournalBatchNumber"] = "LNR0000266" },
+                new Dictionary<string, object> { ["Description"] = "A" }),
+            (new Dictionary<string, object> { ["dataAreaId"] = "1210", ["JournalBatchNumber"] = "LNR0000267" },
+                new Dictionary<string, object> { ["Description"] = "B" })
+        };
+
+        // Act
+        var results = await adapter.BatchUpdateAsync(EntitySet, items, CancellationToken.None);
+
+        // Assert
+        handler.SentRequests.Should().HaveCount(2);
+        handler.SentRequests.Should().AllSatisfy(r => r.Method.Should().Be(HttpMethod.Patch));
+        handler.SentRequests[0].RequestUri!.AbsoluteUri
+            .Should().EndWith("(dataAreaId='1210',JournalBatchNumber='LNR0000266')");
+        handler.SentRequests[1].RequestUri!.AbsoluteUri
+            .Should().EndWith("(dataAreaId='1210',JournalBatchNumber='LNR0000267')");
+        results.Should().HaveCount(2);
+        results.Should().AllSatisfy(r => r.IsSuccess.Should().BeTrue());
+    }
+
+    [Fact]
+    public async Task BatchDelete_CompositeKeys_EmitPerItemKeyedUrls()
+    {
+        // Arrange
+        var (provider, handler) = BuildHarness();
+        handler.Queue(HttpStatusCode.NoContent);
+        handler.Queue(HttpStatusCode.NoContent);
+        var adapter = ResolveAdapter(provider);
+
+        var keys = new List<object>
+        {
+            new Dictionary<string, object> { ["dataAreaId"] = "1210", ["JournalBatchNumber"] = "LNR0000266" },
+            new Dictionary<string, object> { ["dataAreaId"] = "1210", ["JournalBatchNumber"] = "LNR0000267" }
+        };
+
+        // Act
+        var results = await adapter.BatchDeleteAsync(EntitySet, keys, CancellationToken.None);
+
+        // Assert
+        handler.SentRequests.Should().HaveCount(2);
+        handler.SentRequests.Should().AllSatisfy(r => r.Method.Should().Be(HttpMethod.Delete));
+        handler.SentRequests[0].RequestUri!.AbsoluteUri
+            .Should().EndWith("(dataAreaId='1210',JournalBatchNumber='LNR0000266')");
+        handler.SentRequests[1].RequestUri!.AbsoluteUri
+            .Should().EndWith("(dataAreaId='1210',JournalBatchNumber='LNR0000267')");
+        results.Should().HaveCount(2);
+        results.Should().AllSatisfy(r => r.IsSuccess.Should().BeTrue());
+    }
+
+    public static TheoryData<Dictionary<string, object>, string> KeyValueFormattingCases()
+    {
+        var guid = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        var date = new DateOnly(2026, 6, 30);
+        return new TheoryData<Dictionary<string, object>, string>
+        {
+            // Guid keys are emitted unquoted, matching the filter/read literal formatter.
+            { new Dictionary<string, object> { ["RecId"] = guid }, $"(RecId={guid})" },
+            // DateOnly keys are emitted as yyyy-MM-dd.
+            { new Dictionary<string, object> { ["TransDate"] = date }, "(TransDate=2026-06-30)" },
+            // Enum keys are emitted as the D365 qualified-type literal.
+            { new Dictionary<string, object> { ["Status"] = SampleStatus.Posted }, "(Status=Microsoft.Dynamics.DataEntities.SampleStatus'Posted')" }
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(KeyValueFormattingCases))]
+    public async Task CompositeKeyWrite_FormatsGuidDateOnlyAndEnumKeyValues(
+        Dictionary<string, object> key, string expectedKeySegment)
+    {
+        // Arrange
+        var (provider, handler) = BuildHarness();
+        handler.Queue(HttpStatusCode.NoContent);
+        var adapter = ResolveAdapter(provider);
+
+        // Act
+        await adapter.DeleteAsync(EntitySet, key, CancellationToken.None);
+
+        // Assert — the keyed URL segment must match IntegratoRODataExpressionTranslator.FormatValue.
+        handler.SentRequests.Should().HaveCount(1);
+        handler.SentRequests[0].RequestUri!.AbsoluteUri
+            .Should().Be($"{BaseUrl}/{EntitySet}{expectedKeySegment}");
+    }
+
+    [Fact]
+    public async Task CompositeKeyDelete_NotFoundResponse_TreatedAsSuccessByService()
+    {
+        // Arrange — drive end-to-end through ODataService.DeleteAsync (treatNotFoundAsSuccess=true)
+        // so a 404 from the bypass is mapped via ODataExceptionHandler to a success Result.
+        var (provider, handler) = BuildHarness();
+        handler.Queue(HttpStatusCode.NotFound, "{\"error\":{\"message\":\"Not found\"}}");
+        var adapter = ResolveAdapter(provider);
+
+        var service = new ODataService<TestJournalHeader>(
+            adapter, Substitute.For<ILogger<ODataService<TestJournalHeader>>>());
+
+        var header = new TestJournalHeader
+        {
+            DataAreaId = "1210",
+            JournalBatchNumber = "LNR0000266",
+            JournalName = "GenJnl",
+            Description = "To delete"
+        };
+
+        // Act
+        var result = await service.DeleteAsync(header, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        handler.SentRequests[0].Method.Should().Be(HttpMethod.Delete);
+    }
+
+    [Fact]
+    public async Task CompositeKeyUpdate_NonSuccessResponse_ThrowsODataClientExceptionWithStatusAndBody()
+    {
+        // Arrange
+        var (provider, handler) = BuildHarness();
+        const string errorBody = "{\"error\":{\"code\":\"BadRequest\",\"message\":\"Invalid field\"}}";
+        handler.Queue(HttpStatusCode.BadRequest, errorBody);
+        var adapter = ResolveAdapter(provider);
+
+        var key = new Dictionary<string, object>
+        {
+            ["dataAreaId"] = "1210",
+            ["JournalBatchNumber"] = "LNR0000266"
+        };
+        var payload = new Dictionary<string, object> { ["Description"] = "x" };
+
+        // Act
+        Func<Task> act = () => adapter.UpdateAsync<TestJournalHeader>(EntitySet, key, payload, CancellationToken.None);
+
+        // Assert — the thrown exception carries status, body, and URL so the existing
+        // ODataExceptionHandler 400 arm produces a Validation IntegrationError.
+        var exception = (await act.Should().ThrowAsync<ODataClientException>()).Which;
+        exception.StatusCode.Should().Be(400);
+        exception.ResponseBody.Should().Be(errorBody);
+        exception.RequestUrl.Should().EndWith("(dataAreaId='1210',JournalBatchNumber='LNR0000266')");
+    }
+
+    /// <summary>
+    /// A standalone enum used solely to pin the qualified-type key-value formatting in
+    /// <see cref="CompositeKeyWrite_FormatsGuidDateOnlyAndEnumKeyValues"/>.
+    /// </summary>
+    public enum SampleStatus
+    {
+        None = 0,
+        Posted = 1
+    }
+
+    /// <summary>
+    /// A local composite-key entity mirroring the D365 F&O <c>LedgerJournalHeader</c> wire shape
+    /// (camelCase <c>dataAreaId</c> via <c>[JsonPropertyName]</c>, PascalCase
+    /// <c>JournalBatchNumber</c>, both <c>[Key]</c>). Defined here so this test project does not
+    /// take a dependency on <c>IntegratoR.OData.FO</c>.
+    /// </summary>
+    [Table("LedgerJournalHeaders")]
+    public sealed class TestJournalHeader : BaseEntity<string>
+    {
+        [Key]
+        [JsonPropertyName("dataAreaId")]
+        public required string DataAreaId { get; set; }
+
+        [Key]
+        [JsonPropertyName("JournalBatchNumber")]
+        public required string JournalBatchNumber { get; set; }
+
+        [JsonPropertyName("JournalName")]
+        public string? JournalName { get; set; }
+
+        [JsonPropertyName("Description")]
+        public string? Description { get; set; }
+
+        public override object[] GetCompositeKey() => [DataAreaId, JournalBatchNumber];
+    }
+}

--- a/tests/IntegratoR.OData.Tests/Common/Services/ODataServiceCompositeKeyTests.cs
+++ b/tests/IntegratoR.OData.Tests/Common/Services/ODataServiceCompositeKeyTests.cs
@@ -1,0 +1,129 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using IntegratoR.Abstractions.Common.Results;
+using IntegratoR.Abstractions.Domain.Entities;
+using IntegratoR.OData.Common.Services;
+using IntegratoR.OData.Interfaces.Services;
+using IntegratoR.TestKit.Assertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace IntegratoR.OData.Tests.Common.Services;
+
+/// <summary>
+/// Pins <see cref="ODataService{TEntity}"/>'s composite-key building behaviour: deterministic
+/// <c>[Key]</c> ordering by MetadataToken, a Validation failure (not a silent fallback) on a key
+/// count mismatch, and a Validation failure on a null key element — each surfaced BEFORE any
+/// adapter call (assert <c>Received(0)</c>).
+/// </summary>
+public sealed class ODataServiceCompositeKeyTests
+{
+    [Fact]
+    public async Task BuildCompositeKeyObject_OrdersKeyPropertiesByMetadataToken()
+    {
+        // Arrange — the entity declares its [Key] properties in a known source order; the emitted
+        // key dictionary must zip each [Key] wire name to its corresponding value regardless of
+        // GetProperties() ordering.
+        var adapter = Substitute.For<IODataClientAdapter>();
+        object? capturedKey = null;
+        adapter.UpdateAsync<ReverseKeyEntity>(
+            Arg.Any<string>(),
+            Arg.Do<object>(k => capturedKey = k),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new ReverseKeyEntity { First = "1", Second = "2" });
+
+        var service = new ODataService<ReverseKeyEntity>(
+            adapter, Substitute.For<ILogger<ODataService<ReverseKeyEntity>>>());
+
+        // GetCompositeKey returns values in declaration order: [First, Second].
+        var entity = new ReverseKeyEntity { First = "1210", Second = "LNR0000266" };
+
+        // Act
+        await service.UpdateAsync(entity, CancellationToken.None);
+
+        // Assert — declaration order (First then Second) is preserved deterministically.
+        var dict = capturedKey.Should().BeAssignableTo<IDictionary<string, object>>().Subject;
+        dict["first"].Should().Be("1210");
+        dict["second"].Should().Be("LNR0000266");
+    }
+
+    [Fact]
+    public async Task GetByKeyAsync_KeyCountMismatch_ReturnsValidationFailure()
+    {
+        // Arrange — TwoKeyEntity declares two [Key] properties; supply three key values.
+        var adapter = Substitute.For<IODataClientAdapter>();
+        var service = new ODataService<TwoKeyEntity>(
+            adapter, Substitute.For<ILogger<ODataService<TwoKeyEntity>>>());
+
+        // Act
+        var result = await service.GetByKeyAsync(["a", "b", "c"], CancellationToken.None);
+
+        // Assert
+        result.Should().BeFailed();
+        result.Should().HaveErrorType(ErrorType.Validation);
+        result.Errors[0].As<IntegrationError>().Code.Should().EndWith(".KeyCountMismatch");
+        await adapter.DidNotReceiveWithAnyArgs().FindByKeyAsync<TwoKeyEntity>(
+            Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateAsync_NullKeyElement_ReturnsValidationFailure()
+    {
+        // Arrange — entity yields a null second key element, which cannot identify an entity.
+        var adapter = Substitute.For<IODataClientAdapter>();
+        var service = new ODataService<TwoKeyEntity>(
+            adapter, Substitute.For<ILogger<ODataService<TwoKeyEntity>>>());
+
+        var entity = new TwoKeyEntity { First = "1210", Second = null };
+
+        // Act
+        var result = await service.UpdateAsync(entity, CancellationToken.None);
+
+        // Assert
+        result.Should().BeFailed();
+        result.Should().HaveErrorType(ErrorType.Validation);
+        result.Errors[0].As<IntegrationError>().Code.Should().EndWith(".InvalidKey");
+        await adapter.DidNotReceiveWithAnyArgs().UpdateAsync<TwoKeyEntity>(
+            Arg.Any<string>(), Arg.Any<object>(), Arg.Any<object>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Declares its <c>[Key]</c> properties in source order First → Second so the MetadataToken
+    /// ordering test can assert deterministic key-to-value zipping.
+    /// </summary>
+    [Table("ReverseKeyEntities")]
+    public sealed class ReverseKeyEntity : BaseEntity<string>
+    {
+        [Key]
+        [JsonPropertyName("first")]
+        public required string First { get; set; }
+
+        [Key]
+        [JsonPropertyName("second")]
+        public required string Second { get; set; }
+
+        public override object[] GetCompositeKey() => [First, Second];
+    }
+
+    /// <summary>
+    /// A two-key entity whose <c>GetCompositeKey</c> can yield a null element (Second is nullable),
+    /// used to exercise the null-key and count-mismatch Validation failures.
+    /// </summary>
+    [Table("TwoKeyEntities")]
+    public sealed class TwoKeyEntity : BaseEntity<string>
+    {
+        [Key]
+        [JsonPropertyName("first")]
+        public required string First { get; set; }
+
+        [Key]
+        [JsonPropertyName("second")]
+        public string? Second { get; set; }
+
+        public override object[] GetCompositeKey() => [First, Second!];
+    }
+}

--- a/tests/IntegratoR.OData.Tests/Common/Services/ODataServiceTests.cs
+++ b/tests/IntegratoR.OData.Tests/Common/Services/ODataServiceTests.cs
@@ -249,6 +249,7 @@ public class ODataServiceTests
             Arg.Any<Expression<Func<TestEntity, bool>>?>(),
             Arg.Any<Expression<Func<TestEntity, object>>?>(),
             Arg.Any<Expression<Func<TestEntity, object>>?>(),
+            Arg.Any<IReadOnlyList<(Expression<Func<TestEntity, object>> KeySelector, bool Descending)>?>(),
             Arg.Any<int?>(),
             Arg.Any<int?>(),
             Arg.Any<CancellationToken>())
@@ -276,6 +277,7 @@ public class ODataServiceTests
             Arg.Any<Expression<Func<TestEntity, bool>>?>(),
             Arg.Any<Expression<Func<TestEntity, object>>?>(),
             Arg.Any<Expression<Func<TestEntity, object>>?>(),
+            Arg.Any<IReadOnlyList<(Expression<Func<TestEntity, object>> KeySelector, bool Descending)>?>(),
             Arg.Any<int?>(),
             Arg.Any<int?>(),
             Arg.Any<CancellationToken>())
@@ -301,18 +303,21 @@ public class ODataServiceTests
             Arg.Any<Expression<Func<TestEntity, bool>>?>(),
             Arg.Any<Expression<Func<TestEntity, object>>?>(),
             Arg.Any<Expression<Func<TestEntity, object>>?>(),
+            Arg.Any<IReadOnlyList<(Expression<Func<TestEntity, object>> KeySelector, bool Descending)>?>(),
             Arg.Any<int?>(),
             Arg.Any<int?>(),
             Arg.Any<CancellationToken>())
             .Returns(new List<TestEntity>());
 
         // Act
-        var result = await _sut.QueryAsync(skip: 10, top: 5, cancellationToken: CancellationToken.None);
+        IReadOnlyList<(Expression<Func<TestEntity, object>> KeySelector, bool Descending)>? noOrderBy = null;
+        var result = await _sut.QueryAsync(filter: null, orderBy: noOrderBy, skip: 10, top: 5, cancellationToken: CancellationToken.None);
 
         // Assert
         result.Should().BeSuccessful();
         await _client.Received(1).FindEntriesAsync<TestEntity>(
             Arg.Any<string>(),
+            null,
             null,
             null,
             null,
@@ -334,6 +339,7 @@ public class ODataServiceTests
             Arg.Any<Expression<Func<TestEntity, bool>>?>(),
             Arg.Any<Expression<Func<TestEntity, object>>?>(),
             Arg.Any<Expression<Func<TestEntity, object>>?>(),
+            Arg.Any<IReadOnlyList<(Expression<Func<TestEntity, object>> KeySelector, bool Descending)>?>(),
             Arg.Any<int?>(),
             Arg.Any<int?>(),
             Arg.Any<CancellationToken>())
@@ -381,13 +387,82 @@ public class ODataServiceTests
             Arg.Any<Expression<Func<TestEntity, bool>>?>(),
             Arg.Any<Expression<Func<TestEntity, object>>?>(),
             Arg.Any<Expression<Func<TestEntity, object>>?>(),
+            Arg.Any<IReadOnlyList<(Expression<Func<TestEntity, object>> KeySelector, bool Descending)>?>(),
             Arg.Any<int?>(),
             Arg.Any<int?>(),
             Arg.Any<CancellationToken>())
             .Returns(entities);
 
         // Act
-        var result = await _sut.QueryAsync(cancellationToken: CancellationToken.None);
+        IReadOnlyList<(Expression<Func<TestEntity, object>> KeySelector, bool Descending)>? noOrderBy = null;
+        var result = await _sut.QueryAsync(filter: null, orderBy: noOrderBy, cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Should().BeSuccessful();
+    }
+
+    /// <summary>
+    /// Verifies that the new strongly-typed QueryAsync overload forwards its orderBy argument to
+    /// the adapter's FindEntriesAsync — the wiring the old Func-based overload silently dropped.
+    /// </summary>
+    [Fact]
+    public async Task QueryAsync_WithOrderBy_ForwardsOrderByToAdapter()
+    {
+        // Arrange
+        IReadOnlyList<(Expression<Func<TestEntity, object>> KeySelector, bool Descending)>? capturedOrderBy = null;
+        _client.FindEntriesAsync<TestEntity>(
+            Arg.Any<string>(),
+            Arg.Any<Expression<Func<TestEntity, bool>>?>(),
+            Arg.Any<Expression<Func<TestEntity, object>>?>(),
+            Arg.Any<Expression<Func<TestEntity, object>>?>(),
+            Arg.Do<IReadOnlyList<(Expression<Func<TestEntity, object>> KeySelector, bool Descending)>?>(o => capturedOrderBy = o),
+            Arg.Any<int?>(),
+            Arg.Any<int?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new List<TestEntity>());
+
+        var orderBy = new (Expression<Func<TestEntity, object>> KeySelector, bool Descending)[]
+        {
+            (e => e.Id, false),
+            (e => e.Name, true)
+        };
+
+        // Act
+        var result = await _sut.QueryAsync(filter: null, orderBy: orderBy, cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Should().BeSuccessful();
+        capturedOrderBy.Should().NotBeNull();
+        capturedOrderBy.Should().BeEquivalentTo(orderBy);
+    }
+
+    /// <summary>
+    /// Verifies that the [Obsolete] Func-based QueryAsync overload still compiles and returns
+    /// success (its body is retained as a no-op for orderBy). CS0618 is suppressed narrowly here
+    /// because the test intentionally exercises the deprecated overload.
+    /// </summary>
+    [Fact]
+    public async Task QueryAsync_ObsoleteFuncOverload_StillCompilesAndReturnsSuccess()
+    {
+        // Arrange
+        _client.FindEntriesAsync<TestEntity>(
+            Arg.Any<string>(),
+            Arg.Any<Expression<Func<TestEntity, bool>>?>(),
+            Arg.Any<Expression<Func<TestEntity, object>>?>(),
+            Arg.Any<Expression<Func<TestEntity, object>>?>(),
+            Arg.Any<IReadOnlyList<(Expression<Func<TestEntity, object>> KeySelector, bool Descending)>?>(),
+            Arg.Any<int?>(),
+            Arg.Any<int?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new List<TestEntity>());
+
+        // Act
+#pragma warning disable CS0618 // intentionally exercising the obsolete Func-based overload
+        var result = await _sut.QueryAsync(
+            filter: null,
+            orderBy: (Func<IQueryable<TestEntity>, IOrderedQueryable<TestEntity>>?)null,
+            cancellationToken: CancellationToken.None);
+#pragma warning restore CS0618
 
         // Assert
         result.Should().BeSuccessful();
@@ -962,7 +1037,9 @@ public class ODataServiceTests
             Arg.Any<CancellationToken>())
             .Returns(new TestEntityWithD365Attributes { DataAreaId = "USMF", Amount = 100m });
 
-        var entity = new TestEntityWithD365Attributes { DataAreaId = "USMF", Amount = 100m, JournalName = null };
+        // JournalBatchNumber is set so the composite key is valid; the test isolates IsRequired,
+        // not key validation.
+        var entity = new TestEntityWithD365Attributes { DataAreaId = "USMF", JournalBatchNumber = "JN-001", Amount = 100m, JournalName = null };
 
         // Act
         var result = await odataSut.UpdateAsync(entity, CancellationToken.None);

--- a/tests/IntegratoR.TestKit/Doubles/Entities/TestEntity.cs
+++ b/tests/IntegratoR.TestKit/Doubles/Entities/TestEntity.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using IntegratoR.Abstractions.Domain.Entities;
 
 namespace IntegratoR.TestKit.Doubles.Entities;
@@ -11,11 +12,13 @@ public class TestEntity : BaseEntity<string>
     /// <summary>
     /// Gets or sets the primary identifier. First component of the composite key.
     /// </summary>
+    [Key]
     public required string Id { get; set; }
 
     /// <summary>
     /// Gets or sets the partition key. Second component of the composite key.
     /// </summary>
+    [Key]
     public required string PartitionKey { get; set; }
 
     /// <summary>

--- a/tests/IntegratoR.TestKit/Doubles/Entities/TestEntityWithD365Attributes.cs
+++ b/tests/IntegratoR.TestKit/Doubles/Entities/TestEntityWithD365Attributes.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using IntegratoR.Abstractions.Domain.Entities;
 using IntegratoR.OData.Common.Annotations;
 
@@ -13,13 +14,17 @@ public class TestEntityWithD365Attributes : BaseEntity<string>
 {
     /// <summary>
     /// Gets or sets the data area (company). Required, editable on create but not after.
+    /// First component of the composite key.
     /// </summary>
+    [Key]
     [ODataField(AllowEdit = false, IsRequired = true, EdmType = "Edm.String")]
     public required string DataAreaId { get; set; }
 
     /// <summary>
     /// Gets or sets the journal number. Not editable on create (server-generated) or update.
+    /// Second component of the composite key.
     /// </summary>
+    [Key]
     [ODataField(AllowEditOnCreate = false, AllowEdit = false, EdmType = "Edm.String")]
     public string? JournalBatchNumber { get; set; }
 
@@ -41,5 +46,5 @@ public class TestEntityWithD365Attributes : BaseEntity<string>
     public required decimal Amount { get; set; }
 
     /// <inheritdoc/>
-    public override object[] GetCompositeKey() => [DataAreaId, JournalBatchNumber ?? ""];
+    public override object[] GetCompositeKey() => [DataAreaId, JournalBatchNumber!];
 }

--- a/tests/IntegratoR.TestKit/Fakes/FakeHttpMessageHandler.cs
+++ b/tests/IntegratoR.TestKit/Fakes/FakeHttpMessageHandler.cs
@@ -15,12 +15,21 @@ public sealed class FakeHttpMessageHandler : HttpMessageHandler
 {
     private readonly Queue<HttpResponseMessage> _responses = new();
     private readonly List<HttpRequestMessage> _sentRequests = new();
+    private readonly List<string?> _sentRequestBodies = new();
 
     /// <summary>
     /// Gets a read-only view of all <see cref="HttpRequestMessage"/> instances that were sent
     /// through this handler in the order they were received.
     /// </summary>
     public IReadOnlyList<HttpRequestMessage> SentRequests => _sentRequests.AsReadOnly();
+
+    /// <summary>
+    /// Gets a read-only view of the request body strings captured at send time, indexed in
+    /// lockstep with <see cref="SentRequests"/>. Captured eagerly so the body is still readable
+    /// after the caller disposes the <see cref="HttpRequestMessage"/> (which disposes its content).
+    /// A request with no content yields <c>null</c>.
+    /// </summary>
+    public IReadOnlyList<string?> SentRequestBodies => _sentRequestBodies.AsReadOnly();
 
     /// <summary>
     /// Enqueues a pre-built <see cref="HttpResponseMessage"/> to be returned by the next
@@ -51,7 +60,7 @@ public sealed class FakeHttpMessageHandler : HttpMessageHandler
     public HttpClient CreateClient() => new(this, disposeHandler: false);
 
     /// <inheritdoc/>
-    protected override Task<HttpResponseMessage> SendAsync(
+    protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,
         CancellationToken cancellationToken)
     {
@@ -60,6 +69,13 @@ public sealed class FakeHttpMessageHandler : HttpMessageHandler
                 "No more queued responses. Call Queue() before making HTTP requests.");
 
         _sentRequests.Add(request);
-        return Task.FromResult(_responses.Dequeue());
+
+        // Capture the body eagerly so it survives the caller disposing the request.
+        string? body = request.Content is null
+            ? null
+            : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        _sentRequestBodies.Add(body);
+
+        return _responses.Dequeue();
     }
 }


### PR DESCRIPTION
Second of the fix series. Makes D365 F&O composite-key **writes** work (they silently produced malformed URLs via PanoramicData), hardens the composite-key path, and implements `$orderby` end-to-end.

## Changes
- **`ODataClientAdapter`**: new 2nd ctor `(ODataClient, IHttpClientFactory)` (1-arg kept). `Update/Delete/BatchUpdate/BatchDelete` route composite (`IDictionary`) keys through a raw-HttpClient bypass on the named `"ODataClient"` client (auth + Polly inherited) — `EntitySet(field=literal,…)` built via the `IsValidODataFieldName` guard + `FormatValue`; non-2xx throws `ODataNotFoundException`/`ODataClientException` so the existing handler maps it. Batch: any composite ⇒ per-item individual requests; all-single-key ⇒ atomic changeset.
- **`ODataService.BuildCompositeKeyObject`**: `static`, returns `Result<object>`, orders `[Key]` by `MetadataToken`, fails `Validation` on key-count-mismatch / null element (was a silent fallback); key-build hoisted out of the exception-handler lambdas.
- **`LedgerJournalHeader.GetCompositeKey`**: real `null` element (was the literal `"null"`).
- **`$orderby`**: `ToOrderByString` (honours `[JsonPropertyName]`), optional `orderBy` on `FindEntriesAsync`, new typed `QueryAsync` overload, `[Obsolete]` the Func-based one.

## Verification
- `dotnet build` 0 errors; `dotnet test` **533 passed, 0 failed, 0 skipped** (+17).
- `code-reviewer` + `security-reviewer`: **security approved** (no OData-injection surface — field names regex-guarded, values single-quote-escaped; `CreateClient("ODataClient")` keeps the auth chain; token forwarded). Code-review Majors resolved (homogeneous-batch simplification; BaseAddress trailing-slash documented).

## Semver
`+semver: minor` — additive ctor/overloads + `[Obsolete]`; no removals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)