### PR TITLE
refactor(cqrs): command/handler consistency + generic batch handlers (PR-C)

### DIFF
--- a/IntegratoR.Abstractions/Common/CQRS/Commands/CreateBatchCommand.cs
+++ b/IntegratoR.Abstractions/Common/CQRS/Commands/CreateBatchCommand.cs
@@ -11,7 +11,7 @@ namespace IntegratoR.Abstractions.Common.CQRS.Commands
     /// A generic base command for creating new entities in a batch.
     /// </summary>
     /// <typeparam name="TEntity">The type of the entity to create.</typeparam>
-    public record CreateBatchCommand<TEntity>(IEnumerable<TEntity> Entities) : ICommand<Result>
+    public record CreateBatchCommand<TEntity>(IReadOnlyList<TEntity> Entities) : ICommand<Result>
         where TEntity : IEntity
     {
         /// <summary>
@@ -22,7 +22,7 @@ namespace IntegratoR.Abstractions.Common.CQRS.Commands
         {
             return new Dictionary<string, object>
             {
-                { "Count", Entities.Count() }
+                { "Count", Entities.Count }
             };
         }
     }

--- a/IntegratoR.Abstractions/Common/CQRS/Commands/DeleteBatchCommand.cs
+++ b/IntegratoR.Abstractions/Common/CQRS/Commands/DeleteBatchCommand.cs
@@ -11,7 +11,7 @@ namespace IntegratoR.Abstractions.Common.CQRS.Commands
     /// A generic base command for deleting entities in a batch.
     /// </summary>
     /// <typeparam name="TEntity">The type of the entity to create.</typeparam>
-    public record DeleteBatchCommand<TEntity>(IEnumerable<TEntity> Entities) : ICommand<Result>
+    public record DeleteBatchCommand<TEntity>(IReadOnlyList<TEntity> Entities) : ICommand<Result>
         where TEntity : IEntity
     {
         /// <summary>
@@ -22,7 +22,7 @@ namespace IntegratoR.Abstractions.Common.CQRS.Commands
         {
             return new Dictionary<string, object>
             {
-                { "Count", Entities.Count() }
+                { "Count", Entities.Count }
             };
         }
     }

--- a/IntegratoR.Abstractions/Common/CQRS/Commands/UpdateBatchCommand.cs
+++ b/IntegratoR.Abstractions/Common/CQRS/Commands/UpdateBatchCommand.cs
@@ -11,7 +11,7 @@ namespace IntegratoR.Abstractions.Common.CQRS.Commands
     /// A generic base command for updating entities in a batch.
     /// </summary>
     /// <typeparam name="TEntity">The type of the entity to create.</typeparam>
-    public record UpdateBatchCommand<TEntity>(IEnumerable<TEntity> Entities) : ICommand<Result>
+    public record UpdateBatchCommand<TEntity>(IReadOnlyList<TEntity> Entities) : ICommand<Result>
         where TEntity : IEntity
     {
         /// <summary>
@@ -22,7 +22,7 @@ namespace IntegratoR.Abstractions.Common.CQRS.Commands
         {
             return new Dictionary<string, object>
             {
-                { "Count", Entities.Count() }
+                { "Count", Entities.Count }
             };
         }
     }

--- a/IntegratoR.Abstractions/Interfaces/Services/IBatchService.cs
+++ b/IntegratoR.Abstractions/Interfaces/Services/IBatchService.cs
@@ -1,0 +1,44 @@
+using FluentResults;
+using IntegratoR.Abstractions.Interfaces.Entity;
+
+namespace IntegratoR.Abstractions.Interfaces.Services;
+
+/// <summary>
+/// Defines a contract for performing CUD (Create, Update, Delete) operations on multiple
+/// entities in a single batch request.
+/// </summary>
+/// <typeparam name="TEntity">The type of the entity for the batch operations.</typeparam>
+/// <remarks>
+/// Batch operations are critical for performance in high-volume integrations: multiple
+/// individual operations are bundled into a single network round-trip and typically executed
+/// within a single transaction, providing an "all-or-nothing" consistency guarantee.
+///
+/// This interface lives in <c>IntegratoR.Abstractions</c> so the generic batch command handlers
+/// in <c>IntegratoR.Application</c> can depend on it without referencing the OData layer.
+/// </remarks>
+public interface IBatchService<TEntity> where TEntity : IEntity
+{
+    /// <summary>
+    /// Adds a collection of entities in a single atomic batch operation.
+    /// </summary>
+    /// <param name="entities">The collection of entity instances to create.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A non-generic <see cref="Result"/> indicating the overall success or failure of the batch operation.</returns>
+    Task<Result> AddBatchAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates a collection of entities in a single atomic batch operation.
+    /// </summary>
+    /// <param name="entities">The collection of entity instances to update. Each entity must have its key populated.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A non-generic <see cref="Result"/> indicating the overall success or failure of the batch operation.</returns>
+    Task<Result> UpdateBatchAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a collection of entities in a single atomic batch operation.
+    /// </summary>
+    /// <param name="entities">The collection of entity instances to delete. Each entity must have its key populated.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A non-generic <see cref="Result"/> indicating the overall success or failure of the batch operation.</returns>
+    Task<Result> DeleteBatchAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
+}

--- a/IntegratoR.Application/Features/Common/Commands/CreateBatchCommandHandler.cs
+++ b/IntegratoR.Application/Features/Common/Commands/CreateBatchCommandHandler.cs
@@ -1,0 +1,32 @@
+using FluentResults;
+using IntegratoR.Abstractions.Common.CQRS.Commands;
+using IntegratoR.Abstractions.Interfaces.Entity;
+using IntegratoR.Abstractions.Interfaces.Services;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace IntegratoR.Application.Features.Common.Commands;
+
+/// <summary>
+/// A generic handler that can process any command inheriting from <see cref="CreateBatchCommand{TEntity}"/>.
+/// </summary>
+public class CreateBatchCommandHandler<TEntity>
+    : IRequestHandler<CreateBatchCommand<TEntity>, Result>
+    where TEntity : class, IEntity
+{
+    private readonly ILogger<CreateBatchCommandHandler<TEntity>> _logger;
+    private readonly IBatchService<TEntity> _service;
+
+    public CreateBatchCommandHandler(ILogger<CreateBatchCommandHandler<TEntity>> logger, IBatchService<TEntity> service)
+    {
+        _logger = logger;
+        _service = service;
+    }
+
+    public async Task<Result> Handle(CreateBatchCommand<TEntity> request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Creating {Count} {EntityType} entities in batch.", request.Entities.Count, typeof(TEntity).Name);
+
+        return await _service.AddBatchAsync(request.Entities, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/IntegratoR.Application/Features/Common/Commands/DeleteBatchCommandHandler.cs
+++ b/IntegratoR.Application/Features/Common/Commands/DeleteBatchCommandHandler.cs
@@ -1,0 +1,32 @@
+using FluentResults;
+using IntegratoR.Abstractions.Common.CQRS.Commands;
+using IntegratoR.Abstractions.Interfaces.Entity;
+using IntegratoR.Abstractions.Interfaces.Services;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace IntegratoR.Application.Features.Common.Commands;
+
+/// <summary>
+/// A generic handler that can process any command inheriting from <see cref="DeleteBatchCommand{TEntity}"/>.
+/// </summary>
+public class DeleteBatchCommandHandler<TEntity>
+    : IRequestHandler<DeleteBatchCommand<TEntity>, Result>
+    where TEntity : class, IEntity
+{
+    private readonly ILogger<DeleteBatchCommandHandler<TEntity>> _logger;
+    private readonly IBatchService<TEntity> _service;
+
+    public DeleteBatchCommandHandler(ILogger<DeleteBatchCommandHandler<TEntity>> logger, IBatchService<TEntity> service)
+    {
+        _logger = logger;
+        _service = service;
+    }
+
+    public async Task<Result> Handle(DeleteBatchCommand<TEntity> request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Deleting {Count} {EntityType} entities in batch.", request.Entities.Count, typeof(TEntity).Name);
+
+        return await _service.DeleteBatchAsync(request.Entities, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/IntegratoR.Application/Features/Common/Commands/UpdateBatchCommandHandler.cs
+++ b/IntegratoR.Application/Features/Common/Commands/UpdateBatchCommandHandler.cs
@@ -1,0 +1,32 @@
+using FluentResults;
+using IntegratoR.Abstractions.Common.CQRS.Commands;
+using IntegratoR.Abstractions.Interfaces.Entity;
+using IntegratoR.Abstractions.Interfaces.Services;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace IntegratoR.Application.Features.Common.Commands;
+
+/// <summary>
+/// A generic handler that can process any command inheriting from <see cref="UpdateBatchCommand{TEntity}"/>.
+/// </summary>
+public class UpdateBatchCommandHandler<TEntity>
+    : IRequestHandler<UpdateBatchCommand<TEntity>, Result>
+    where TEntity : class, IEntity
+{
+    private readonly ILogger<UpdateBatchCommandHandler<TEntity>> _logger;
+    private readonly IBatchService<TEntity> _service;
+
+    public UpdateBatchCommandHandler(ILogger<UpdateBatchCommandHandler<TEntity>> logger, IBatchService<TEntity> service)
+    {
+        _logger = logger;
+        _service = service;
+    }
+
+    public async Task<Result> Handle(UpdateBatchCommand<TEntity> request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Updating {Count} {EntityType} entities in batch.", request.Entities.Count, typeof(TEntity).Name);
+
+        return await _service.UpdateBatchAsync(request.Entities, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/IntegratoR.Hosting/Extensions/ServiceCollectionExtensions.cs
+++ b/IntegratoR.Hosting/Extensions/ServiceCollectionExtensions.cs
@@ -103,7 +103,27 @@ public static class IntegratoRServiceCollectionExtensions
             services.PostConfigure(builder.FOPostConfigure);
         }
 
-        // 6. Register consumer FluentValidation validators. Consumer MediatR handlers — including
+        // 6. Register the F&O FluentValidation validators. The F&O layer (AddODataClientFOProxy)
+        //    registers its MediatR handlers but not its validators; wiring them here keeps the
+        //    FluentValidation.DependencyInjectionExtensions dependency in the composition root.
+        //    This registers the NON-GENERIC GetDimensionOrdersQueryValidator, which then fires in
+        //    the MediatR ValidationBehaviour.
+        //
+        //    KNOWN LIMITATION: AddValidatorsFromAssembly's assembly scanner does NOT register
+        //    OPEN-GENERIC validators (it cannot build a closed IValidator<> service type from a
+        //    partially-open generic). This affects BOTH the generic baseline validators in
+        //    IntegratoR.Application (CreateCommandValidator<T> etc.) AND the thin derived per-command
+        //    validators in IntegratoR.OData.FO (CreateLedgerJournalLineCommandValidator<T> etc.).
+        //    Consequently, generic/open-generic command validation does NOT run through the pipeline
+        //    today — a pre-existing framework-wide gap, not introduced here. The derived FO
+        //    validators are still useful and are unit-proven against the concrete FO commands in
+        //    GenericValidatorReuseTests; closing the open-generic pipeline gap is deferred (it needs
+        //    a per-entity closed-validator registration mechanism, out of scope for PR-C).
+        services.AddValidatorsFromAssembly(
+            typeof(IntegratoR.OData.FO.Domain.Entities.LedgerJournal.LedgerJournalHeader).Assembly,
+            includeInternalTypes: true);
+
+        // 7. Register consumer FluentValidation validators. Consumer MediatR handlers — including
         //    the closed generic CRUD/query handlers for consumer entities — are already registered
         //    by the combined RegisterGenericHandlers scan in step 3b, so they must NOT be scanned
         //    again here (a second AddMediatR pass would emit duplicate handler registrations).

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalHeader/CreateLedgerJournalHeaderCommand.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalHeader/CreateLedgerJournalHeaderCommand.cs
@@ -1,5 +1,4 @@
 using IntegratoR.Abstractions.Common.CQRS.Commands;
-using IntegratoR.Abstractions.Interfaces.Commands;
 using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
 
 namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.CreateLedgerJournalHeader;

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalHeader/CreateLedgerJournalHeaderCommandValidator.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalHeader/CreateLedgerJournalHeaderCommandValidator.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
+
+namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.CreateLedgerJournalHeader;
+
+/// <summary>
+/// Thin derived validator that re-applies the generic <c>CreateCommand</c> baseline rule
+/// (entity not null) under the concrete command's closed type
+/// (<c>IValidator&lt;CreateLedgerJournalHeaderCommand&lt;TEntity&gt;&gt;</c>).
+///
+/// NOTE: currently dormant in the MediatR pipeline — FluentValidation's
+/// <c>AddValidatorsFromAssembly</c> cannot register open-generic validators (see
+/// <c>ServiceCollectionExtensions.cs</c> step 6). Unit-tested directly in
+/// <c>GenericValidatorReuseTests</c>; will fire once a closed-generic validator-registration
+/// mechanism is added.
+/// </summary>
+public sealed class CreateLedgerJournalHeaderCommandValidator<TEntity>
+    : AbstractValidator<CreateLedgerJournalHeaderCommand<TEntity>>
+    where TEntity : LedgerJournalHeader
+{
+    public CreateLedgerJournalHeaderCommandValidator()
+    {
+        RuleFor(x => x.Entity)
+            .NotNull().WithMessage("Entity must not be null.");
+    }
+}

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalHeader/CreateLedgerJournalHeaderHandler.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalHeader/CreateLedgerJournalHeaderHandler.cs
@@ -7,10 +7,17 @@ using Microsoft.Extensions.Logging;
 
 namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.CreateLedgerJournalHeader;
 
-public class CreateLedgerJournalHeaderHandler<TEntity>(ILogger<CreateLedgerJournalHeaderHandler<TEntity>> logger, IService<TEntity> service) : IRequestHandler<CreateLedgerJournalHeaderCommand<TEntity>, Result<TEntity>> where TEntity : LedgerJournalHeader
+/// <summary>Creates a single LedgerJournalHeader in D365 F&amp;O, emitting domain-specific structured logs. Retained over the generic CreateCommandHandler&lt;T&gt; because it adds journal-context logging.</summary>
+public class CreateLedgerJournalHeaderHandler<TEntity> : IRequestHandler<CreateLedgerJournalHeaderCommand<TEntity>, Result<TEntity>> where TEntity : LedgerJournalHeader
 {
-    private readonly ILogger<CreateLedgerJournalHeaderHandler<TEntity>> _logger = logger;
-    private readonly IService<TEntity> _service = service;
+    private readonly ILogger<CreateLedgerJournalHeaderHandler<TEntity>> _logger;
+    private readonly IService<TEntity> _service;
+
+    public CreateLedgerJournalHeaderHandler(ILogger<CreateLedgerJournalHeaderHandler<TEntity>> logger, IService<TEntity> service)
+    {
+        _logger = logger;
+        _service = service;
+    }
 
     public async Task<Result<TEntity>> Handle(CreateLedgerJournalHeaderCommand<TEntity> request, CancellationToken cancellationToken)
     {

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalHeader/CreateLedgerJournalHeadersCommand.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalHeader/CreateLedgerJournalHeadersCommand.cs
@@ -1,17 +1,16 @@
 using IntegratoR.Abstractions.Common.CQRS.Commands;
-using IntegratoR.Abstractions.Interfaces.Commands;
 using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
 
 namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.CreateLedgerJournalHeader;
 
-public record CreateLedgerJournalHeadersCommand<TEntity>(IEnumerable<TEntity> LedgerJournalHeaders) : CreateBatchCommand<TEntity>(LedgerJournalHeaders) where TEntity : LedgerJournalHeader
+public record CreateLedgerJournalHeadersCommand<TEntity>(IReadOnlyList<TEntity> LedgerJournalHeaders) : CreateBatchCommand<TEntity>(LedgerJournalHeaders) where TEntity : LedgerJournalHeader
 {
     public override IReadOnlyDictionary<string, object> GetLoggingContext()
     {
         return new Dictionary<string, object>
         {
             { "EntityType", typeof(TEntity).Name  },
-            { "Count", LedgerJournalHeaders.Count() },
+            { "Count", LedgerJournalHeaders.Count },
             { "JournalNames", string.Join(", ", LedgerJournalHeaders.Select(j => j.JournalName)) }
         };
     }

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalHeader/CreateLedgerJournalHeadersCommandValidator.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalHeader/CreateLedgerJournalHeadersCommandValidator.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
+
+namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.CreateLedgerJournalHeader;
+
+/// <summary>
+/// Thin derived validator that re-applies the generic <c>CreateBatchCommand</c> baseline rules
+/// (entities not null, not empty) under the concrete batch command's closed type
+/// (<c>IValidator&lt;CreateLedgerJournalHeadersCommand&lt;TEntity&gt;&gt;</c>).
+///
+/// NOTE: currently dormant in the MediatR pipeline — FluentValidation's
+/// <c>AddValidatorsFromAssembly</c> cannot register open-generic validators (see
+/// <c>ServiceCollectionExtensions.cs</c> step 6). Unit-tested directly in
+/// <c>GenericValidatorReuseTests</c>; will fire once a closed-generic validator-registration
+/// mechanism is added.
+/// </summary>
+public sealed class CreateLedgerJournalHeadersCommandValidator<TEntity>
+    : AbstractValidator<CreateLedgerJournalHeadersCommand<TEntity>>
+    where TEntity : LedgerJournalHeader
+{
+    public CreateLedgerJournalHeadersCommandValidator()
+    {
+        RuleFor(x => x.Entities)
+            .Cascade(CascadeMode.Stop)
+            .NotNull().WithMessage("Entities collection must not be null.")
+            .Must(e => e.Any()).WithMessage("Entities collection must not be empty.");
+    }
+}

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalHeader/CreateLedgerJournalHeadersHandler.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalHeader/CreateLedgerJournalHeadersHandler.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.CreateLedgerJournalHeader;
 
+/// <summary>Creates a batch of LedgerJournalHeader entities in D365 F&amp;O, emitting domain-specific structured logs. Retained over the generic CreateBatchCommandHandler&lt;T&gt; because it adds journal-context (Count) logging.</summary>
 public class CreateLedgerJournalHeadersHandler<TEntity> : IRequestHandler<CreateLedgerJournalHeadersCommand<TEntity>, Result> where TEntity : LedgerJournalHeader
 {
     private readonly ILogger<CreateLedgerJournalHeadersHandler<TEntity>> _logger;
@@ -20,14 +21,14 @@ public class CreateLedgerJournalHeadersHandler<TEntity> : IRequestHandler<Create
 
     public async Task<Result> Handle(CreateLedgerJournalHeadersCommand<TEntity> request, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Creating {Count} LedgerJournalHeader entities in F&O.", request.LedgerJournalHeaders.Count());
+        _logger.LogInformation("Creating {Count} LedgerJournalHeader entities in F&O.", request.LedgerJournalHeaders.Count);
 
         var addResult = await _service.AddBatchAsync(request.LedgerJournalHeaders, cancellationToken).ConfigureAwait(false);
 
         return addResult.Match(
             onSuccess: () =>
             {
-                _logger.LogInformation("Successfully created {Count} LedgerJournalHeader entities in F&O.", request.LedgerJournalHeaders.Count());
+                _logger.LogInformation("Successfully created {Count} LedgerJournalHeader entities in F&O.", request.LedgerJournalHeaders.Count);
 
                 return Result.Ok();
             },

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalLine/CreateLedgerJournalLineCommand.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalLine/CreateLedgerJournalLineCommand.cs
@@ -1,12 +1,7 @@
-using FluentResults;
-using IntegratoR.Abstractions.Interfaces.Commands;
+using IntegratoR.Abstractions.Common.CQRS.Commands;
 using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
+
 namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.CreateLedgerJournalLine;
 
-public record CreateLedgerJournalLineCommand<TEntity>(TEntity LedgerJournalLine) : ICommand<Result<TEntity>> where TEntity : LedgerJournalLine
-{
-    public IReadOnlyDictionary<string, object> GetLoggingContext()
-    {
-        return LedgerJournalLine.GetLoggingContext();
-    }
-}
+public record CreateLedgerJournalLineCommand<TEntity>(TEntity LedgerJournalLine)
+    : CreateCommand<TEntity>(LedgerJournalLine) where TEntity : LedgerJournalLine;

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalLine/CreateLedgerJournalLineCommandValidator.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalLine/CreateLedgerJournalLineCommandValidator.cs
@@ -1,0 +1,30 @@
+using FluentValidation;
+using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
+
+namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.CreateLedgerJournalLine;
+
+/// <summary>
+/// Thin derived validator that re-applies the generic <c>CreateCommand</c> baseline rule
+/// (entity not null) under the concrete command's closed type
+/// (<c>IValidator&lt;CreateLedgerJournalLineCommand&lt;TEntity&gt;&gt;</c>).
+/// </summary>
+/// <remarks>
+/// The container resolves <c>IValidator&lt;ConcreteCommand&gt;</c> by exact closed type, so inheriting
+/// the generic base command is not enough — the validator must close over the concrete command type.
+///
+/// NOTE: currently dormant in the MediatR pipeline — FluentValidation's
+/// <c>AddValidatorsFromAssembly</c> cannot register open-generic validators (see
+/// <c>ServiceCollectionExtensions.cs</c> step 6). Unit-tested directly in
+/// <c>GenericValidatorReuseTests</c>; will fire once a closed-generic validator-registration
+/// mechanism is added.
+/// </remarks>
+public sealed class CreateLedgerJournalLineCommandValidator<TEntity>
+    : AbstractValidator<CreateLedgerJournalLineCommand<TEntity>>
+    where TEntity : LedgerJournalLine
+{
+    public CreateLedgerJournalLineCommandValidator()
+    {
+        RuleFor(x => x.Entity)
+            .NotNull().WithMessage("Entity must not be null.");
+    }
+}

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalLine/CreateLedgerJournalLineHandler.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalLine/CreateLedgerJournalLineHandler.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.CreateLedgerJournalLine;
 
+/// <summary>Creates a single LedgerJournalLine in D365 F&amp;O, emitting domain-specific structured logs. Retained over the generic CreateCommandHandler&lt;T&gt; because it adds journal-context logging.</summary>
 public class CreateLedgerJournalLineHandler<TEntity> : IRequestHandler<CreateLedgerJournalLineCommand<TEntity>, Result<TEntity>> where TEntity : LedgerJournalLine
 {
     private readonly ILogger<CreateLedgerJournalLineHandler<TEntity>> _logger;
@@ -20,7 +21,7 @@ public class CreateLedgerJournalLineHandler<TEntity> : IRequestHandler<CreateLed
 
     public async Task<Result<TEntity>> Handle(CreateLedgerJournalLineCommand<TEntity> request, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Creating a new Ledger Journal Line for Header: {JournalBatchNumber} in Company: {Comany}",
+        _logger.LogInformation("Creating a new Ledger Journal Line for Header: {JournalBatchNumber} in Company: {Company}",
             request.LedgerJournalLine.JournalBatchNumber,
             request.LedgerJournalLine.DataAreaId);
 

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalLine/CreateLedgerJournalLinesCommand.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalLine/CreateLedgerJournalLinesCommand.cs
@@ -1,16 +1,16 @@
-using FluentResults;
-using IntegratoR.Abstractions.Interfaces.Commands;
+using IntegratoR.Abstractions.Common.CQRS.Commands;
 using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
 
 namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.CreateLedgerJournalLine;
 
-public record CreateLedgerJournalLinesCommand<TEntity>(IEnumerable<TEntity> LedgerJournalLines) : ICommand<Result> where TEntity : LedgerJournalLine
+public record CreateLedgerJournalLinesCommand<TEntity>(IReadOnlyList<TEntity> LedgerJournalLines)
+    : CreateBatchCommand<TEntity>(LedgerJournalLines) where TEntity : LedgerJournalLine
 {
-    public IReadOnlyDictionary<string, object> GetLoggingContext()
+    public override IReadOnlyDictionary<string, object> GetLoggingContext()
     {
         return new Dictionary<string, object>
         {
-            { "Count", LedgerJournalLines.Count() },
+            { "Count", LedgerJournalLines.Count },
             { "JournalNames", string.Join(", ", LedgerJournalLines.Select(j => j.JournalBatchNumber)) }
         };
     }

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalLine/CreateLedgerJournalLinesCommandValidator.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalLine/CreateLedgerJournalLinesCommandValidator.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
+
+namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.CreateLedgerJournalLine;
+
+/// <summary>
+/// Thin derived validator that re-applies the generic <c>CreateBatchCommand</c> baseline rules
+/// (entities not null, not empty) under the concrete batch command's closed type
+/// (<c>IValidator&lt;CreateLedgerJournalLinesCommand&lt;TEntity&gt;&gt;</c>).
+///
+/// NOTE: currently dormant in the MediatR pipeline — FluentValidation's
+/// <c>AddValidatorsFromAssembly</c> cannot register open-generic validators (see
+/// <c>ServiceCollectionExtensions.cs</c> step 6). Unit-tested directly in
+/// <c>GenericValidatorReuseTests</c>; will fire once a closed-generic validator-registration
+/// mechanism is added.
+/// </summary>
+public sealed class CreateLedgerJournalLinesCommandValidator<TEntity>
+    : AbstractValidator<CreateLedgerJournalLinesCommand<TEntity>>
+    where TEntity : LedgerJournalLine
+{
+    public CreateLedgerJournalLinesCommandValidator()
+    {
+        RuleFor(x => x.Entities)
+            .Cascade(CascadeMode.Stop)
+            .NotNull().WithMessage("Entities collection must not be null.")
+            .Must(e => e.Any()).WithMessage("Entities collection must not be empty.");
+    }
+}

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalLine/CreateLedgerJournalLinesHandler.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/CreateLedgerJournalLine/CreateLedgerJournalLinesHandler.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.CreateLedgerJournalLine;
 
+/// <summary>Creates a batch of LedgerJournalLine entities in D365 F&amp;O, emitting domain-specific structured logs. Retained over the generic CreateBatchCommandHandler&lt;T&gt; because it adds journal-context (Count) logging.</summary>
 public class CreateLedgerJournalLinesHandler<TEntity> : IRequestHandler<CreateLedgerJournalLinesCommand<TEntity>, Result> where TEntity : LedgerJournalLine
 {
     private readonly ILogger<CreateLedgerJournalLinesHandler<TEntity>> _logger;
@@ -20,14 +21,14 @@ public class CreateLedgerJournalLinesHandler<TEntity> : IRequestHandler<CreateLe
 
     public async Task<Result> Handle(CreateLedgerJournalLinesCommand<TEntity> request, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Creating {Count} Ledger Journal Lines in F&O.", request.LedgerJournalLines.Count());
+        _logger.LogInformation("Creating {Count} Ledger Journal Lines in F&O.", request.LedgerJournalLines.Count);
 
         var addResult = await _service.AddBatchAsync(request.LedgerJournalLines, cancellationToken).ConfigureAwait(false);
 
         return addResult.Match(
             onSuccess: () =>
             {
-                _logger.LogInformation("Successfully created {Count} Ledger Journal Lines in F&O.", request.LedgerJournalLines.Count());
+                _logger.LogInformation("Successfully created {Count} Ledger Journal Lines in F&O.", request.LedgerJournalLines.Count);
                 return Result.Ok();
             },
             onFailure: error =>

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalHeader/UpdateLedgerJournalHeaderCommand.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalHeader/UpdateLedgerJournalHeaderCommand.cs
@@ -1,13 +1,7 @@
-using FluentResults;
-using IntegratoR.Abstractions.Interfaces.Commands;
+using IntegratoR.Abstractions.Common.CQRS.Commands;
 using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
 
 namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.UpdateLedgerJournalHeader;
 
-public record UpdateLedgerJournalHeaderCommand<TEntity>(TEntity LedgerJournalHeader) : ICommand<Result<TEntity>> where TEntity : LedgerJournalHeader
-{
-    public IReadOnlyDictionary<string, object> GetLoggingContext()
-    {
-        return LedgerJournalHeader.GetLoggingContext();
-    }
-}
+public record UpdateLedgerJournalHeaderCommand<TEntity>(TEntity LedgerJournalHeader)
+    : UpdateCommand<TEntity>(LedgerJournalHeader) where TEntity : LedgerJournalHeader;

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalHeader/UpdateLedgerJournalHeaderCommandValidator.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalHeader/UpdateLedgerJournalHeaderCommandValidator.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
+
+namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.UpdateLedgerJournalHeader;
+
+/// <summary>
+/// Thin derived validator that re-applies the generic <c>UpdateCommand</c> baseline rule
+/// (entity not null) under the concrete command's closed type
+/// (<c>IValidator&lt;UpdateLedgerJournalHeaderCommand&lt;TEntity&gt;&gt;</c>).
+///
+/// NOTE: currently dormant in the MediatR pipeline — FluentValidation's
+/// <c>AddValidatorsFromAssembly</c> cannot register open-generic validators (see
+/// <c>ServiceCollectionExtensions.cs</c> step 6). Unit-tested directly in
+/// <c>GenericValidatorReuseTests</c>; will fire once a closed-generic validator-registration
+/// mechanism is added.
+/// </summary>
+public sealed class UpdateLedgerJournalHeaderCommandValidator<TEntity>
+    : AbstractValidator<UpdateLedgerJournalHeaderCommand<TEntity>>
+    where TEntity : LedgerJournalHeader
+{
+    public UpdateLedgerJournalHeaderCommandValidator()
+    {
+        RuleFor(x => x.Entity)
+            .NotNull().WithMessage("Entity must not be null.");
+    }
+}

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalHeader/UpdateLedgerJournalHeaderHandler.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalHeader/UpdateLedgerJournalHeaderHandler.cs
@@ -7,12 +7,13 @@ using Microsoft.Extensions.Logging;
 
 namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.UpdateLedgerJournalHeader;
 
+/// <summary>Updates a single LedgerJournalHeader in D365 F&amp;O, emitting domain-specific structured logs. Retained over the generic UpdateCommandHandler&lt;T&gt; because it adds journal-context logging.</summary>
 public class UpdateLedgerJournalHeaderHandler<TEntity> : IRequestHandler<UpdateLedgerJournalHeaderCommand<TEntity>, Result<TEntity>> where TEntity : LedgerJournalHeader
 {
-    private readonly ILogger<UpdateLedgerJournalHeaderCommand<TEntity>> _logger;
+    private readonly ILogger<UpdateLedgerJournalHeaderHandler<TEntity>> _logger;
     private readonly IService<TEntity> _service;
 
-    public UpdateLedgerJournalHeaderHandler(ILogger<UpdateLedgerJournalHeaderCommand<TEntity>> logger, IService<TEntity> service)
+    public UpdateLedgerJournalHeaderHandler(ILogger<UpdateLedgerJournalHeaderHandler<TEntity>> logger, IService<TEntity> service)
     {
         _logger = logger;
         _service = service;

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalHeader/UpdateLedgerJournalHeadersCommand.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalHeader/UpdateLedgerJournalHeadersCommand.cs
@@ -1,16 +1,15 @@
-using FluentResults;
-using IntegratoR.Abstractions.Interfaces.Commands;
+using IntegratoR.Abstractions.Common.CQRS.Commands;
 using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
 
 namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.UpdateLedgerJournalHeader;
 
-public record UpdateLedgerJournalHeadersCommand<TEntity>(IEnumerable<TEntity> LedgerJournalHeaders) : ICommand<Result> where TEntity : LedgerJournalHeader
+public record UpdateLedgerJournalHeadersCommand<TEntity>(IReadOnlyList<TEntity> LedgerJournalHeaders) : UpdateBatchCommand<TEntity>(LedgerJournalHeaders) where TEntity : LedgerJournalHeader
 {
-    public IReadOnlyDictionary<string, object> GetLoggingContext()
+    public override IReadOnlyDictionary<string, object> GetLoggingContext()
     {
         return new Dictionary<string, object>
         {
-            { "Count", LedgerJournalHeaders.Count() },
+            { "Count", LedgerJournalHeaders.Count },
             { "JournalNames", string.Join(", ", LedgerJournalHeaders.Select(j => j.JournalName)) }
         };
     }

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalHeader/UpdateLedgerJournalHeadersCommandValidator.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalHeader/UpdateLedgerJournalHeadersCommandValidator.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
+
+namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.UpdateLedgerJournalHeader;
+
+/// <summary>
+/// Thin derived validator that re-applies the generic <c>UpdateBatchCommand</c> baseline rules
+/// (entities not null, not empty) under the concrete batch command's closed type
+/// (<c>IValidator&lt;UpdateLedgerJournalHeadersCommand&lt;TEntity&gt;&gt;</c>).
+///
+/// NOTE: currently dormant in the MediatR pipeline — FluentValidation's
+/// <c>AddValidatorsFromAssembly</c> cannot register open-generic validators (see
+/// <c>ServiceCollectionExtensions.cs</c> step 6). Unit-tested directly in
+/// <c>GenericValidatorReuseTests</c>; will fire once a closed-generic validator-registration
+/// mechanism is added.
+/// </summary>
+public sealed class UpdateLedgerJournalHeadersCommandValidator<TEntity>
+    : AbstractValidator<UpdateLedgerJournalHeadersCommand<TEntity>>
+    where TEntity : LedgerJournalHeader
+{
+    public UpdateLedgerJournalHeadersCommandValidator()
+    {
+        RuleFor(x => x.Entities)
+            .Cascade(CascadeMode.Stop)
+            .NotNull().WithMessage("Entities collection must not be null.")
+            .Must(e => e.Any()).WithMessage("Entities collection must not be empty.");
+    }
+}

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalHeader/UpdateLedgerJournalHeadersHandler.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalHeader/UpdateLedgerJournalHeadersHandler.cs
@@ -7,12 +7,13 @@ using Microsoft.Extensions.Logging;
 
 namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.UpdateLedgerJournalHeader;
 
-public class UpdateLedgerJournalHandler<TEntity> : IRequestHandler<UpdateLedgerJournalHeadersCommand<TEntity>, Result> where TEntity : LedgerJournalHeader
+/// <summary>Updates a batch of LedgerJournalHeader entities in D365 F&amp;O, emitting domain-specific structured logs. Retained over the generic UpdateBatchCommandHandler&lt;T&gt; because it adds journal-context (Count) logging.</summary>
+public class UpdateLedgerJournalHeadersHandler<TEntity> : IRequestHandler<UpdateLedgerJournalHeadersCommand<TEntity>, Result> where TEntity : LedgerJournalHeader
 {
-    private readonly ILogger<UpdateLedgerJournalHeadersCommand<TEntity>> _logger;
+    private readonly ILogger<UpdateLedgerJournalHeadersHandler<TEntity>> _logger;
     private readonly IODataBatchService<TEntity> _service;
 
-    public UpdateLedgerJournalHandler(ILogger<UpdateLedgerJournalHeadersCommand<TEntity>> logger, IODataBatchService<TEntity> service)
+    public UpdateLedgerJournalHeadersHandler(ILogger<UpdateLedgerJournalHeadersHandler<TEntity>> logger, IODataBatchService<TEntity> service)
     {
         _logger = logger;
         _service = service;
@@ -27,7 +28,7 @@ public class UpdateLedgerJournalHandler<TEntity> : IRequestHandler<UpdateLedgerJ
         return result.Match(
             onSuccess: () =>
             {
-                _logger.LogInformation("Successfully updated {Count} Ledger Journal Headers.", request.LedgerJournalHeaders.Count());
+                _logger.LogInformation("Successfully updated {Count} Ledger Journal Headers.", request.LedgerJournalHeaders.Count);
                 return Result.Ok();
             },
             onFailure: error =>

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalLine/UpdateLedgerJournalLineCommand.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalLine/UpdateLedgerJournalLineCommand.cs
@@ -1,13 +1,7 @@
-using FluentResults;
-using IntegratoR.Abstractions.Interfaces.Commands;
+using IntegratoR.Abstractions.Common.CQRS.Commands;
 using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
 
 namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.UpdateLedgerJournalLine;
 
-public record UpdateLedgerJournalLineCommand<TEntity>(TEntity LedgerJournalLine) : ICommand<Result<TEntity>> where TEntity : LedgerJournalLine
-{
-    public IReadOnlyDictionary<string, object> GetLoggingContext()
-    {
-        return LedgerJournalLine.GetLoggingContext();
-    }
-}
+public record UpdateLedgerJournalLineCommand<TEntity>(TEntity LedgerJournalLine)
+    : UpdateCommand<TEntity>(LedgerJournalLine) where TEntity : LedgerJournalLine;

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalLine/UpdateLedgerJournalLineCommandValidator.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalLine/UpdateLedgerJournalLineCommandValidator.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
+
+namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.UpdateLedgerJournalLine;
+
+/// <summary>
+/// Thin derived validator that re-applies the generic <c>UpdateCommand</c> baseline rule
+/// (entity not null) under the concrete command's closed type
+/// (<c>IValidator&lt;UpdateLedgerJournalLineCommand&lt;TEntity&gt;&gt;</c>).
+///
+/// NOTE: currently dormant in the MediatR pipeline — FluentValidation's
+/// <c>AddValidatorsFromAssembly</c> cannot register open-generic validators (see
+/// <c>ServiceCollectionExtensions.cs</c> step 6). Unit-tested directly in
+/// <c>GenericValidatorReuseTests</c>; will fire once a closed-generic validator-registration
+/// mechanism is added.
+/// </summary>
+public sealed class UpdateLedgerJournalLineCommandValidator<TEntity>
+    : AbstractValidator<UpdateLedgerJournalLineCommand<TEntity>>
+    where TEntity : LedgerJournalLine
+{
+    public UpdateLedgerJournalLineCommandValidator()
+    {
+        RuleFor(x => x.Entity)
+            .NotNull().WithMessage("Entity must not be null.");
+    }
+}

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalLine/UpdateLedgerJournalLineHandler.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalLine/UpdateLedgerJournalLineHandler.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.UpdateLedgerJournalLine;
 
+/// <summary>Updates a single LedgerJournalLine in D365 F&amp;O, emitting domain-specific structured logs. Retained over the generic UpdateCommandHandler&lt;T&gt; because it adds journal-context logging.</summary>
 public class UpdateLedgerJournalLineHandler<TEntity> : IRequestHandler<UpdateLedgerJournalLineCommand<TEntity>, Result<TEntity>> where TEntity : LedgerJournalLine
 {
     private readonly ILogger<UpdateLedgerJournalLineHandler<TEntity>> _logger;

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalLine/UpdateLedgerJournalLinesCommand.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalLine/UpdateLedgerJournalLinesCommand.cs
@@ -1,16 +1,15 @@
-using FluentResults;
-using IntegratoR.Abstractions.Interfaces.Commands;
+using IntegratoR.Abstractions.Common.CQRS.Commands;
 using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
 
 namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.UpdateLedgerJournalLine
 {
-    public record UpdateLedgerJournalLinesCommand<TEntity>(IEnumerable<TEntity> LedgerJournalLines) : ICommand<Result> where TEntity : LedgerJournalLine
+    public record UpdateLedgerJournalLinesCommand<TEntity>(IReadOnlyList<TEntity> LedgerJournalLines) : UpdateBatchCommand<TEntity>(LedgerJournalLines) where TEntity : LedgerJournalLine
     {
-        public IReadOnlyDictionary<string, object> GetLoggingContext()
+        public override IReadOnlyDictionary<string, object> GetLoggingContext()
         {
             return new Dictionary<string, object>
             {
-                { "Count", LedgerJournalLines.Count() },
+                { "Count", LedgerJournalLines.Count },
                 { "JournalBatchNumbers", string.Join(",", LedgerJournalLines.Select(l => l.JournalBatchNumber).Distinct()) }
             };
         }

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalLine/UpdateLedgerJournalLinesCommandValidator.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalLine/UpdateLedgerJournalLinesCommandValidator.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
+
+namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.UpdateLedgerJournalLine;
+
+/// <summary>
+/// Thin derived validator that re-applies the generic <c>UpdateBatchCommand</c> baseline rules
+/// (entities not null, not empty) under the concrete batch command's closed type
+/// (<c>IValidator&lt;UpdateLedgerJournalLinesCommand&lt;TEntity&gt;&gt;</c>).
+///
+/// NOTE: currently dormant in the MediatR pipeline — FluentValidation's
+/// <c>AddValidatorsFromAssembly</c> cannot register open-generic validators (see
+/// <c>ServiceCollectionExtensions.cs</c> step 6). Unit-tested directly in
+/// <c>GenericValidatorReuseTests</c>; will fire once a closed-generic validator-registration
+/// mechanism is added.
+/// </summary>
+public sealed class UpdateLedgerJournalLinesCommandValidator<TEntity>
+    : AbstractValidator<UpdateLedgerJournalLinesCommand<TEntity>>
+    where TEntity : LedgerJournalLine
+{
+    public UpdateLedgerJournalLinesCommandValidator()
+    {
+        RuleFor(x => x.Entities)
+            .Cascade(CascadeMode.Stop)
+            .NotNull().WithMessage("Entities collection must not be null.")
+            .Must(e => e.Any()).WithMessage("Entities collection must not be empty.");
+    }
+}

--- a/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalLine/UpdateLedgerJournalLinesHandler.cs
+++ b/IntegratoR.OData.FO/Features/Commands/LedgerJournals/UpdateLedgerJournalLine/UpdateLedgerJournalLinesHandler.cs
@@ -7,27 +7,28 @@ using Microsoft.Extensions.Logging;
 
 namespace IntegratoR.OData.FO.Features.Commands.LedgerJournals.UpdateLedgerJournalLine
 {
+    /// <summary>Updates a batch of LedgerJournalLine entities in D365 F&amp;O, emitting domain-specific structured logs. Retained over the generic UpdateBatchCommandHandler&lt;T&gt; because it adds journal-context (Count) logging.</summary>
     public class UpdateLedgerJournalLinesHandler<TEntity> : IRequestHandler<UpdateLedgerJournalLinesCommand<TEntity>, Result> where TEntity : LedgerJournalLine
     {
-        private ILogger<UpdateLedgerJournalLinesHandler<TEntity>> _logger;
-        private IODataBatchService<TEntity> _batchService;
+        private readonly ILogger<UpdateLedgerJournalLinesHandler<TEntity>> _logger;
+        private readonly IODataBatchService<TEntity> _service;
 
-        public UpdateLedgerJournalLinesHandler(ILogger<UpdateLedgerJournalLinesHandler<TEntity>> logger, IODataBatchService<TEntity> batchService)
+        public UpdateLedgerJournalLinesHandler(ILogger<UpdateLedgerJournalLinesHandler<TEntity>> logger, IODataBatchService<TEntity> service)
         {
             _logger = logger;
-            _batchService = batchService;
+            _service = service;
         }
 
         public async Task<Result> Handle(UpdateLedgerJournalLinesCommand<TEntity> request, CancellationToken cancellationToken)
         {
             _logger.LogInformation("Updating Ledger Journal Lines in batch...");
 
-            var result = await _batchService.UpdateBatchAsync(request.LedgerJournalLines, cancellationToken).ConfigureAwait(false);
+            var result = await _service.UpdateBatchAsync(request.LedgerJournalLines, cancellationToken).ConfigureAwait(false);
 
             return result.Match(
                 onSuccess: () =>
                 {
-                    _logger.LogInformation("Successfully updated {Count} Ledger Journal Lines.", request.LedgerJournalLines.Count());
+                    _logger.LogInformation("Successfully updated {Count} Ledger Journal Lines.", request.LedgerJournalLines.Count);
                     return Result.Ok();
                 },
                 onFailure: error =>

--- a/IntegratoR.OData.FO/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQuery.cs
+++ b/IntegratoR.OData.FO/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQuery.cs
@@ -1,13 +1,13 @@
 using FluentResults;
 using IntegratoR.Abstractions.Interfaces.Queries;
 using IntegratoR.OData.FO.Domain.Enums.Dimensions;
-using IntegratoR.OData.FO.Domain.Models.FinancialDimensions;
+using DimensionFormatModel = IntegratoR.OData.FO.Domain.Models.FinancialDimensions.DimensionFormat;
 
 namespace IntegratoR.OData.FO.Features.Queries.Dimensions.GetDimensionOrder;
 
-public record GetDimensionOrdersQuery(string dimensionFormat, DimensionHierarchyType hierarchyType) : ICacheableQuery<Result<DimensionFormat>>
+public record GetDimensionOrdersQuery(string DimensionFormat, DimensionHierarchyType HierarchyType) : ICacheableQuery<Result<DimensionFormatModel>>
 {
-    public string CacheKey => $"{nameof(GetDimensionOrdersQuery)}-{dimensionFormat}-{hierarchyType}";
+    public string CacheKey => $"{nameof(GetDimensionOrdersQuery)}-{DimensionFormat}-{HierarchyType}";
 
     public TimeSpan? CacheDuration => TimeSpan.FromMinutes(15);
 
@@ -18,7 +18,7 @@ public record GetDimensionOrdersQuery(string dimensionFormat, DimensionHierarchy
 
     public object[] GetCacheKeyValues()
     {
-        return new object[] { nameof(GetDimensionOrdersQuery), dimensionFormat, hierarchyType }
+        return new object[] { nameof(GetDimensionOrdersQuery), DimensionFormat, HierarchyType }
         ;
     }
 
@@ -26,8 +26,8 @@ public record GetDimensionOrdersQuery(string dimensionFormat, DimensionHierarchy
     {
         return new Dictionary<string, object>
         {
-            { "DimensionFormat", dimensionFormat },
-            { "HierarchyType", hierarchyType.ToString() }
+            { "DimensionFormat", DimensionFormat },
+            { "HierarchyType", HierarchyType.ToString() }
         };
     }
 }

--- a/IntegratoR.OData.FO/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryHandler.cs
+++ b/IntegratoR.OData.FO/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryHandler.cs
@@ -27,8 +27,8 @@ public class GetDimensionOrdersQueryHandler : IRequestHandler<GetDimensionOrders
 
     public async Task<Result<DimensionFormat>> Handle(GetDimensionOrdersQuery request, CancellationToken cancellationToken)
     {
-        var dimensionFormatName = request.dimensionFormat;
-        var dimensionHierarchyType = request.hierarchyType;
+        var dimensionFormatName = request.DimensionFormat;
+        var dimensionHierarchyType = request.HierarchyType;
 
         _logger.LogInformation("Fetching dimension format '{DimensionFormatName}' of type '{DimensionHierarchyType}' from F&O.", dimensionFormatName, dimensionHierarchyType);
 

--- a/IntegratoR.OData.FO/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryValidator.cs
+++ b/IntegratoR.OData.FO/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryValidator.cs
@@ -6,10 +6,10 @@ public class GetDimensionOrdersQueryValidator : AbstractValidator<GetDimensionOr
 {
     public GetDimensionOrdersQueryValidator()
     {
-        RuleFor(x => x.dimensionFormat)
+        RuleFor(x => x.DimensionFormat)
             .NotEmpty().WithMessage("Dimension format must be provided.")
             .MaximumLength(100).WithMessage("Dimension format must not exceed 100 characters.");
-        RuleFor(x => x.hierarchyType)
+        RuleFor(x => x.HierarchyType)
             .IsInEnum().WithMessage("Hierarchy type must be a valid enum value.");
     }
 }

--- a/IntegratoR.OData/Common/Extensions/ApplicationDependencyInjection.cs
+++ b/IntegratoR.OData/Common/Extensions/ApplicationDependencyInjection.cs
@@ -195,6 +195,7 @@ internal static class ApplicationDependencyInjection
         services.AddScoped(typeof(IntegratoR.Abstractions.Interfaces.Services.IService<>), typeof(ODataService<>));
         services.AddScoped(typeof(IODataService<>), typeof(ODataService<>));
         services.AddScoped(typeof(IODataBatchService<>), typeof(ODataService<>));
+        services.AddScoped(typeof(IntegratoR.Abstractions.Interfaces.Services.IBatchService<>), typeof(ODataService<>));
     }
 
     /// <summary>

--- a/IntegratoR.OData/Interfaces/Services/IODataBatchService.cs
+++ b/IntegratoR.OData/Interfaces/Services/IODataBatchService.cs
@@ -1,5 +1,5 @@
-using FluentResults;
 using IntegratoR.Abstractions.Interfaces.Entity;
+using IntegratoR.Abstractions.Interfaces.Services;
 
 // FILE-LEVEL DOCUMENTATION
 // ---------------------------------------------------------------------------------------------
@@ -14,48 +14,21 @@ namespace IntegratoR.OData.Interfaces.Services;
 
 /// <summary>
 /// Defines a contract for performing CUD (Create, Update, Delete) operations on multiple
-/// entities in a single batch request, leveraging the OData `$batch` capability.
+/// entities in a single batch request, leveraging the OData <c>$batch</c> capability.
 /// </summary>
 /// <typeparam name="TEntity">The type of the entity for the batch operations.</typeparam>
-/// <typeparam name="TKey">The type of the entity's primary key.</typeparam>
 /// <remarks>
 /// Using batch operations is critical for performance in high-volume integrations. It allows
 /// multiple individual operations to be bundled into a single network round-trip to the
-/// D365 F&O server. These operations are typically executed within a single transaction,
+/// D365 F&amp;O server. These operations are typically executed within a single transaction,
 /// providing an "all-or-nothing" guarantee for data consistency.
+///
+/// The batch members themselves are declared on the layer-agnostic
+/// <see cref="IBatchService{TEntity}"/> (in <c>IntegratoR.Abstractions</c>) so the generic
+/// batch command handlers can depend on the abstraction without referencing the OData layer.
+/// This interface is the OData-specific marker that <see cref="IBatchService{TEntity}"/>
+/// implementations register against.
 /// </remarks>
-public interface IODataBatchService<TEntity> where TEntity : IEntity
+public interface IODataBatchService<TEntity> : IBatchService<TEntity> where TEntity : IEntity
 {
-    /// <summary>
-    /// Adds a collection of entities in a single atomic batch operation.
-    /// </summary>
-    /// <param name="entities">The collection of entity instances to create.</param>
-    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-    /// <returns>A non-generic <see cref="Result"/> indicating the overall success or failure of the batch operation.</returns>
-    /// <remarks>
-    /// This method bundles multiple OData POST requests into a single `$batch` request.
-    /// </remarks>
-    Task<Result> AddBatchAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Updates a collection of entities in a single atomic batch operation.
-    /// </summary>
-    /// <param name="entities">The collection of entity instances to update. Each entity must have its key populated.</param>
-    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-    /// <returns>A non-generic <see cref="Result"/> indicating the overall success or failure of the batch operation.</returns>
-    /// <remarks>
-    /// This method bundles multiple OData PATCH requests into a single `$batch` request.
-    /// </remarks>
-    Task<Result> UpdateBatchAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Deletes a collection of entities by their unique identifiers in a single atomic batch operation.
-    /// </summary>
-    /// <param name="ids">The collection of primary keys of the entities to delete.</param>
-    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-    /// <returns>A non-generic <see cref="Result"/> indicating the overall success or failure of the batch operation.</returns>
-    /// <remarks>
-    /// This method bundles multiple OData DELETE requests into a single `$batch` request.
-    /// </remarks>
-    Task<Result> DeleteBatchAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
 }

--- a/tests/IntegratoR.Abstractions.Tests/Common/CQRS/Commands/CqrsCommandRecordTests.cs
+++ b/tests/IntegratoR.Abstractions.Tests/Common/CQRS/Commands/CqrsCommandRecordTests.cs
@@ -1,6 +1,8 @@
+using System.Collections;
 using FluentAssertions;
 using IntegratoR.Abstractions.Common.CQRS.Commands;
 using IntegratoR.TestKit.Builders;
+using IntegratoR.TestKit.Doubles.Entities;
 using Xunit;
 
 namespace IntegratoR.Abstractions.Tests.Common.CQRS.Commands;
@@ -132,5 +134,60 @@ public sealed class CqrsCommandRecordTests
 
         // Assert
         context.Should().ContainKey("Count").WhoseValue.Should().Be(1);
+    }
+
+    /// <summary>
+    /// Regression for the multiple-enumeration fix. The batch command ctor now takes
+    /// <c>IReadOnlyList&lt;T&gt;</c> and <c>GetLoggingContext()</c> reads the O(1) <c>.Count</c> property
+    /// instead of LINQ <c>Count()</c>, so it must not enumerate the sequence. This is pinned with a
+    /// counting <c>IReadOnlyList&lt;T&gt;</c> wrapper that records every <c>GetEnumerator()</c> call.
+    /// </summary>
+    [Fact]
+    public void CreateBatchCommand_GetLoggingContext_UsesCountProperty_DoesNotEnumerate()
+    {
+        // Arrange
+        var inner = new[]
+        {
+            TestEntityBuilder.Default().WithId("ce-001").Build(),
+            TestEntityBuilder.Default().WithId("ce-002").Build(),
+            TestEntityBuilder.Default().WithId("ce-003").Build()
+        };
+        var counting = new CountingReadOnlyList<TestEntity>(inner);
+        var command = new CreateBatchCommand<TestEntity>(counting);
+
+        // Act — call twice to prove neither call enumerates.
+        var first = command.GetLoggingContext();
+        var second = command.GetLoggingContext();
+
+        // Assert — O(1) Count returned, sequence never enumerated, same materialised instance kept.
+        first.Should().ContainKey("Count").WhoseValue.Should().Be(3);
+        second.Should().ContainKey("Count").WhoseValue.Should().Be(3);
+        counting.GetEnumeratorCallCount.Should().Be(0);
+        command.Entities.Should().BeSameAs(counting);
+    }
+
+    /// <summary>
+    /// An <see cref="IReadOnlyList{T}"/> wrapper that records how many times the sequence is
+    /// enumerated, used to prove <c>GetLoggingContext()</c> reads <c>.Count</c> without enumerating.
+    /// </summary>
+    private sealed class CountingReadOnlyList<T> : IReadOnlyList<T>
+    {
+        private readonly IReadOnlyList<T> _inner;
+
+        public CountingReadOnlyList(IReadOnlyList<T> inner) => _inner = inner;
+
+        public int GetEnumeratorCallCount { get; private set; }
+
+        public T this[int index] => _inner[index];
+
+        public int Count => _inner.Count;
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            GetEnumeratorCallCount++;
+            return _inner.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/tests/IntegratoR.Application.Tests/Features/Common/Validators/ValidatorTests.cs
+++ b/tests/IntegratoR.Application.Tests/Features/Common/Validators/ValidatorTests.cs
@@ -89,7 +89,7 @@ public class ValidatorTests
     {
         // Arrange
         var validator = new CreateBatchCommandValidator<TestEntity>();
-        var command = new CreateBatchCommand<TestEntity>(Enumerable.Empty<TestEntity>());
+        var command = new CreateBatchCommand<TestEntity>(Array.Empty<TestEntity>());
 
         // Act
         var result = validator.Validate(command);
@@ -175,7 +175,7 @@ public class ValidatorTests
     {
         // Arrange
         var validator = new UpdateBatchCommandValidator<TestEntity>();
-        var command = new UpdateBatchCommand<TestEntity>(Enumerable.Empty<TestEntity>());
+        var command = new UpdateBatchCommand<TestEntity>(Array.Empty<TestEntity>());
 
         // Act
         var result = validator.Validate(command);
@@ -261,7 +261,7 @@ public class ValidatorTests
     {
         // Arrange
         var validator = new DeleteBatchCommandValidator<TestEntity>();
-        var command = new DeleteBatchCommand<TestEntity>(Enumerable.Empty<TestEntity>());
+        var command = new DeleteBatchCommand<TestEntity>(Array.Empty<TestEntity>());
 
         // Act
         var result = validator.Validate(command);

--- a/tests/IntegratoR.Hosting.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/tests/IntegratoR.Hosting.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -388,6 +388,129 @@ public class ServiceCollectionExtensionsTests
         }
     }
 
+    // The generic batch handlers inject IBatchService<TEntity> (declared in IntegratoR.Abstractions
+    // so the Application layer can depend on it without referencing OData). These tests substitute
+    // a closed IBatchService<LedgerJournalHeader> so the generic batch handlers resolve a fake and
+    // pin that the new generic batch handlers are closed by the RegisterGenericHandlers scan and
+    // dispatch to the correct IBatchService method.
+    private static (ServiceProvider Provider, IBatchService<LedgerJournalHeader> Service) BuildProviderWithSubstitutedBatchService()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        IConfiguration configuration = CreateMinimalConfiguration();
+
+        services.AddIntegratoR(configuration);
+
+        IBatchService<LedgerJournalHeader> substitute = Substitute.For<IBatchService<LedgerJournalHeader>>();
+        services.AddScoped(_ => substitute);
+
+        return (services.BuildServiceProvider(), substitute);
+    }
+
+    [Fact]
+    public async Task AddIntegratoR_ResolvesGenericCreateBatchCommandHandler_ForFOEntity()
+    {
+        // Arrange
+        (ServiceProvider provider, IBatchService<LedgerJournalHeader> service) = BuildProviderWithSubstitutedBatchService();
+        await using (provider)
+        {
+            service.AddBatchAsync(Arg.Any<IEnumerable<LedgerJournalHeader>>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(Result.Ok()));
+
+            using IServiceScope scope = provider.CreateScope();
+            IMediator mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            // Act
+            Result result =
+                await mediator.Send(new CreateBatchCommand<LedgerJournalHeader>(new[] { CreateTestHeader() }), TestContext.Current.CancellationToken);
+
+            // Assert
+            result.Should().BeSuccessful();
+            await service.Received(1).AddBatchAsync(Arg.Any<IEnumerable<LedgerJournalHeader>>(), Arg.Any<CancellationToken>());
+        }
+    }
+
+    [Fact]
+    public async Task AddIntegratoR_ResolvesGenericUpdateBatchCommandHandler_ForFOEntity()
+    {
+        // Arrange
+        (ServiceProvider provider, IBatchService<LedgerJournalHeader> service) = BuildProviderWithSubstitutedBatchService();
+        await using (provider)
+        {
+            service.UpdateBatchAsync(Arg.Any<IEnumerable<LedgerJournalHeader>>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(Result.Ok()));
+
+            using IServiceScope scope = provider.CreateScope();
+            IMediator mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            // Act
+            Result result =
+                await mediator.Send(new UpdateBatchCommand<LedgerJournalHeader>(new[] { CreateTestHeader() }), TestContext.Current.CancellationToken);
+
+            // Assert
+            result.Should().BeSuccessful();
+            await service.Received(1).UpdateBatchAsync(Arg.Any<IEnumerable<LedgerJournalHeader>>(), Arg.Any<CancellationToken>());
+        }
+    }
+
+    [Fact]
+    public async Task AddIntegratoR_ResolvesGenericDeleteBatchCommandHandler_ForFOEntity()
+    {
+        // Arrange
+        (ServiceProvider provider, IBatchService<LedgerJournalHeader> service) = BuildProviderWithSubstitutedBatchService();
+        await using (provider)
+        {
+            service.DeleteBatchAsync(Arg.Any<IEnumerable<LedgerJournalHeader>>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(Result.Ok()));
+
+            using IServiceScope scope = provider.CreateScope();
+            IMediator mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            // Act
+            Result result =
+                await mediator.Send(new DeleteBatchCommand<LedgerJournalHeader>(new[] { CreateTestHeader() }), TestContext.Current.CancellationToken);
+
+            // Assert
+            result.Should().BeSuccessful();
+            await service.Received(1).DeleteBatchAsync(Arg.Any<IEnumerable<LedgerJournalHeader>>(), Arg.Any<CancellationToken>());
+        }
+    }
+
+    // Pinned behaviour for PR-C: AddIntegratoR now registers the F&O FluentValidation validators
+    // (step 6). GetDimensionOrdersQueryValidator — a non-generic validator — therefore fires in the
+    // MediatR ValidationBehaviour: an invalid (empty DimensionFormat) query is short-circuited with
+    // a Validation failure before the handler runs. (NOTE: open-generic validators such as the
+    // generic CreateCommandValidator<T> and the thin per-command derived validators are NOT
+    // discoverable by AddValidatorsFromAssembly, so generic command validation does not run through
+    // the pipeline today — a pre-existing framework-wide limitation, see the PR-C report. The
+    // derived validators are unit-proven against the concrete FO commands in
+    // GenericValidatorReuseTests.)
+    [Fact]
+    public async Task AddIntegratoR_ValidationBehaviour_FiresFOValidator_ForGetDimensionOrdersQuery()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        IConfiguration configuration = CreateMinimalConfiguration();
+        services.AddIntegratoR(configuration);
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+        IMediator mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        // Act — an empty DimensionFormat violates the validator's NotEmpty rule; validation must
+        // short-circuit before the handler attempts any OData call.
+        var result = await mediator.Send(
+            new IntegratoR.OData.FO.Features.Queries.Dimensions.GetDimensionOrder.GetDimensionOrdersQuery(
+                string.Empty,
+                IntegratoR.OData.FO.Domain.Enums.Dimensions.DimensionHierarchyType.DataEntityDefaultDimensionFormat),
+            TestContext.Current.CancellationToken);
+
+        // Assert — failed with the validation error code (proving the validator fired in the pipeline).
+        result.Should().BeFailed();
+        result.Should().HaveErrorCode("Validation.Error");
+    }
+
     [Fact]
     public async Task AddIntegratoR_ResolvesGenericGetByFilterQueryHandler_ForFOEntity()
     {

--- a/tests/IntegratoR.OData.FO.Tests/Features/Commands/LedgerJournals/GenericValidatorReuseTests.cs
+++ b/tests/IntegratoR.OData.FO.Tests/Features/Commands/LedgerJournals/GenericValidatorReuseTests.cs
@@ -1,0 +1,174 @@
+using FluentAssertions;
+using IntegratoR.Abstractions.Common.CQRS.Commands;
+using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
+using IntegratoR.OData.FO.Features.Commands.LedgerJournals.CreateLedgerJournalHeader;
+using IntegratoR.OData.FO.Features.Commands.LedgerJournals.CreateLedgerJournalLine;
+using IntegratoR.OData.FO.Features.Commands.LedgerJournals.UpdateLedgerJournalHeader;
+using IntegratoR.OData.FO.Features.Commands.LedgerJournals.UpdateLedgerJournalLine;
+using Xunit;
+
+namespace IntegratoR.OData.FO.Tests.Features.Commands.LedgerJournals;
+
+/// <summary>
+/// Proves two things for the FO LedgerJournal commands after PR-C:
+/// <list type="number">
+/// <item>Each FO single/batch command IS-A generic base command (compile-gated assignments),
+/// so the generic command pipeline applies to them.</item>
+/// <item>The thin derived per-command validator runs the baseline rule for the concrete FO
+/// command type — which is what the MediatR <c>ValidationBehaviour</c> resolves and executes
+/// (the container resolves <c>IValidator&lt;ConcreteCommand&gt;</c> by exact closed type, so the
+/// generic base validator alone would never fire for the derived command).</item>
+/// </list>
+/// </summary>
+public class GenericValidatorReuseTests
+{
+    private static LedgerJournalLine BuildLine() => new()
+    {
+        DataAreaId = "USMF",
+        JournalBatchNumber = "GJ001",
+        LineNumber = 1.0m,
+        AccountDisplayValue = "110110-001-023",
+        CurrencyCode = "USD",
+        TransDate = DateTimeOffset.UtcNow
+    };
+
+    private static LedgerJournalHeader BuildHeader() => new()
+    {
+        DataAreaId = "USMF",
+        JournalName = "GenJnl",
+        Description = "Test journal"
+    };
+
+    [Fact]
+    public void CreateLedgerJournalLineCommand_IsA_CreateCommand_AndDerivedValidatorFlagsNullEntity()
+    {
+        // IS-A: this assignment ONLY compiles because the FO command now inherits CreateCommand<T>.
+        CreateCommand<LedgerJournalLine> asBase = new CreateLedgerJournalLineCommand<LedgerJournalLine>(null!);
+        asBase.Should().NotBeNull();
+
+        var validator = new CreateLedgerJournalLineCommandValidator<LedgerJournalLine>();
+
+        var invalid = validator.Validate(new CreateLedgerJournalLineCommand<LedgerJournalLine>(null!));
+        invalid.IsValid.Should().BeFalse();
+        invalid.Errors.Should().ContainSingle(e => e.PropertyName == "Entity");
+
+        var valid = validator.Validate(new CreateLedgerJournalLineCommand<LedgerJournalLine>(BuildLine()));
+        valid.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CreateLedgerJournalHeaderCommand_IsA_CreateCommand_AndDerivedValidatorFlagsNullEntity()
+    {
+        CreateCommand<LedgerJournalHeader> asBase = new CreateLedgerJournalHeaderCommand<LedgerJournalHeader>(null!);
+        asBase.Should().NotBeNull();
+
+        var validator = new CreateLedgerJournalHeaderCommandValidator<LedgerJournalHeader>();
+
+        var invalid = validator.Validate(new CreateLedgerJournalHeaderCommand<LedgerJournalHeader>(null!));
+        invalid.IsValid.Should().BeFalse();
+        invalid.Errors.Should().ContainSingle(e => e.PropertyName == "Entity");
+
+        var valid = validator.Validate(new CreateLedgerJournalHeaderCommand<LedgerJournalHeader>(BuildHeader()));
+        valid.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UpdateLedgerJournalLineCommand_IsA_UpdateCommand_AndDerivedValidatorFlagsNullEntity()
+    {
+        UpdateCommand<LedgerJournalLine> asBase = new UpdateLedgerJournalLineCommand<LedgerJournalLine>(null!);
+        asBase.Should().NotBeNull();
+
+        var validator = new UpdateLedgerJournalLineCommandValidator<LedgerJournalLine>();
+
+        var invalid = validator.Validate(new UpdateLedgerJournalLineCommand<LedgerJournalLine>(null!));
+        invalid.IsValid.Should().BeFalse();
+        invalid.Errors.Should().ContainSingle(e => e.PropertyName == "Entity");
+
+        var valid = validator.Validate(new UpdateLedgerJournalLineCommand<LedgerJournalLine>(BuildLine()));
+        valid.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UpdateLedgerJournalHeaderCommand_IsA_UpdateCommand_AndDerivedValidatorFlagsNullEntity()
+    {
+        UpdateCommand<LedgerJournalHeader> asBase = new UpdateLedgerJournalHeaderCommand<LedgerJournalHeader>(null!);
+        asBase.Should().NotBeNull();
+
+        var validator = new UpdateLedgerJournalHeaderCommandValidator<LedgerJournalHeader>();
+
+        var invalid = validator.Validate(new UpdateLedgerJournalHeaderCommand<LedgerJournalHeader>(null!));
+        invalid.IsValid.Should().BeFalse();
+        invalid.Errors.Should().ContainSingle(e => e.PropertyName == "Entity");
+
+        var valid = validator.Validate(new UpdateLedgerJournalHeaderCommand<LedgerJournalHeader>(BuildHeader()));
+        valid.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CreateLedgerJournalLinesCommand_IsA_CreateBatchCommand_AndDerivedValidatorFlagsEmptyBatch()
+    {
+        CreateBatchCommand<LedgerJournalLine> asBase =
+            new CreateLedgerJournalLinesCommand<LedgerJournalLine>([]);
+        asBase.Should().NotBeNull();
+
+        var validator = new CreateLedgerJournalLinesCommandValidator<LedgerJournalLine>();
+
+        var empty = validator.Validate(new CreateLedgerJournalLinesCommand<LedgerJournalLine>([]));
+        empty.IsValid.Should().BeFalse();
+        empty.Errors.Should().NotBeEmpty();
+
+        var valid = validator.Validate(new CreateLedgerJournalLinesCommand<LedgerJournalLine>([BuildLine()]));
+        valid.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UpdateLedgerJournalHeadersCommand_IsA_UpdateBatchCommand_AndDerivedValidatorFlagsEmptyBatch()
+    {
+        UpdateBatchCommand<LedgerJournalHeader> asBase =
+            new UpdateLedgerJournalHeadersCommand<LedgerJournalHeader>([]);
+        asBase.Should().NotBeNull();
+
+        var validator = new UpdateLedgerJournalHeadersCommandValidator<LedgerJournalHeader>();
+
+        var empty = validator.Validate(new UpdateLedgerJournalHeadersCommand<LedgerJournalHeader>([]));
+        empty.IsValid.Should().BeFalse();
+        empty.Errors.Should().NotBeEmpty();
+
+        var valid = validator.Validate(new UpdateLedgerJournalHeadersCommand<LedgerJournalHeader>([BuildHeader()]));
+        valid.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CreateLedgerJournalHeadersCommand_IsA_CreateBatchCommand_AndDerivedValidatorFlagsEmptyBatch()
+    {
+        CreateBatchCommand<LedgerJournalHeader> asBase =
+            new CreateLedgerJournalHeadersCommand<LedgerJournalHeader>([]);
+        asBase.Should().NotBeNull();
+
+        var validator = new CreateLedgerJournalHeadersCommandValidator<LedgerJournalHeader>();
+
+        var empty = validator.Validate(new CreateLedgerJournalHeadersCommand<LedgerJournalHeader>([]));
+        empty.IsValid.Should().BeFalse();
+        empty.Errors.Should().NotBeEmpty();
+
+        var valid = validator.Validate(new CreateLedgerJournalHeadersCommand<LedgerJournalHeader>([BuildHeader()]));
+        valid.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UpdateLedgerJournalLinesCommand_IsA_UpdateBatchCommand_AndDerivedValidatorFlagsEmptyBatch()
+    {
+        UpdateBatchCommand<LedgerJournalLine> asBase =
+            new UpdateLedgerJournalLinesCommand<LedgerJournalLine>([]);
+        asBase.Should().NotBeNull();
+
+        var validator = new UpdateLedgerJournalLinesCommandValidator<LedgerJournalLine>();
+
+        var empty = validator.Validate(new UpdateLedgerJournalLinesCommand<LedgerJournalLine>([]));
+        empty.IsValid.Should().BeFalse();
+        empty.Errors.Should().NotBeEmpty();
+
+        var valid = validator.Validate(new UpdateLedgerJournalLinesCommand<LedgerJournalLine>([BuildLine()]));
+        valid.IsValid.Should().BeTrue();
+    }
+}

--- a/tests/IntegratoR.OData.FO.Tests/Features/Commands/LedgerJournals/UpdateLedgerJournalHeader/UpdateLedgerJournalHeaderHandlerTests.cs
+++ b/tests/IntegratoR.OData.FO.Tests/Features/Commands/LedgerJournals/UpdateLedgerJournalHeader/UpdateLedgerJournalHeaderHandlerTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 namespace IntegratoR.OData.FO.Tests.Features.Commands.LedgerJournals.UpdateLedgerJournalHeader;
 
 /// <summary>
-/// Tests for <see cref="UpdateLedgerJournalHeaderHandler{TEntity}"/> and <see cref="UpdateLedgerJournalHandler{TEntity}"/>
+/// Tests for <see cref="UpdateLedgerJournalHeaderHandler{TEntity}"/> and <see cref="UpdateLedgerJournalHeadersHandler{TEntity}"/>
 /// covering success and failure paths for single and batch update operations.
 /// </summary>
 public class UpdateLedgerJournalHeaderHandlerTests
@@ -33,7 +33,7 @@ public class UpdateLedgerJournalHeaderHandlerTests
     {
         // Arrange
         var service = Substitute.For<IService<LedgerJournalHeader>>();
-        var logger = Substitute.For<ILogger<UpdateLedgerJournalHeaderCommand<LedgerJournalHeader>>>();
+        var logger = Substitute.For<ILogger<UpdateLedgerJournalHeaderHandler<LedgerJournalHeader>>>();
         var handler = new UpdateLedgerJournalHeaderHandler<LedgerJournalHeader>(logger, service);
 
         var header = BuildHeader();
@@ -58,7 +58,7 @@ public class UpdateLedgerJournalHeaderHandlerTests
     {
         // Arrange
         var service = Substitute.For<IService<LedgerJournalHeader>>();
-        var logger = Substitute.For<ILogger<UpdateLedgerJournalHeaderCommand<LedgerJournalHeader>>>();
+        var logger = Substitute.For<ILogger<UpdateLedgerJournalHeaderHandler<LedgerJournalHeader>>>();
         var handler = new UpdateLedgerJournalHeaderHandler<LedgerJournalHeader>(logger, service);
 
         var header = BuildHeader();
@@ -78,15 +78,14 @@ public class UpdateLedgerJournalHeaderHandlerTests
 
     /// <summary>
     /// Verifies that the batch handler returns a success result when UpdateBatchAsync succeeds.
-    /// Note: the batch update header handler class is named UpdateLedgerJournalHandler (not UpdateLedgerJournalHeadersHandler).
     /// </summary>
     [Fact]
     public async Task Handle_BatchHeaders_Success_ReturnsOk()
     {
         // Arrange
         var service = Substitute.For<IODataBatchService<LedgerJournalHeader>>();
-        var logger = Substitute.For<ILogger<UpdateLedgerJournalHeadersCommand<LedgerJournalHeader>>>();
-        var handler = new UpdateLedgerJournalHandler<LedgerJournalHeader>(logger, service);
+        var logger = Substitute.For<ILogger<UpdateLedgerJournalHeadersHandler<LedgerJournalHeader>>>();
+        var handler = new UpdateLedgerJournalHeadersHandler<LedgerJournalHeader>(logger, service);
 
         var headers = new[] { BuildHeader(), BuildHeader() };
         service.UpdateBatchAsync(headers, Arg.Any<CancellationToken>())
@@ -109,8 +108,8 @@ public class UpdateLedgerJournalHeaderHandlerTests
     {
         // Arrange
         var service = Substitute.For<IODataBatchService<LedgerJournalHeader>>();
-        var logger = Substitute.For<ILogger<UpdateLedgerJournalHeadersCommand<LedgerJournalHeader>>>();
-        var handler = new UpdateLedgerJournalHandler<LedgerJournalHeader>(logger, service);
+        var logger = Substitute.For<ILogger<UpdateLedgerJournalHeadersHandler<LedgerJournalHeader>>>();
+        var handler = new UpdateLedgerJournalHeadersHandler<LedgerJournalHeader>(logger, service);
 
         var headers = new[] { BuildHeader() };
         var error = new IntegrationError("LedgerJournalHeader.BatchUpdateFailed", "Batch service error", ErrorType.Failure);

--- a/tests/IntegratoR.OData.FO.Tests/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryValidatorTests.cs
+++ b/tests/IntegratoR.OData.FO.Tests/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryValidatorTests.cs
@@ -45,7 +45,7 @@ public class GetDimensionOrdersQueryValidatorTests
         var result = _sut.TestValidate(query);
 
         // Assert
-        result.ShouldHaveValidationErrorFor(q => q.dimensionFormat);
+        result.ShouldHaveValidationErrorFor(q => q.DimensionFormat);
     }
 
     /// <summary>
@@ -64,7 +64,7 @@ public class GetDimensionOrdersQueryValidatorTests
         var result = _sut.TestValidate(query);
 
         // Assert
-        result.ShouldHaveValidationErrorFor(q => q.dimensionFormat);
+        result.ShouldHaveValidationErrorFor(q => q.DimensionFormat);
     }
 
     /// <summary>
@@ -82,6 +82,6 @@ public class GetDimensionOrdersQueryValidatorTests
         var result = _sut.TestValidate(query);
 
         // Assert
-        result.ShouldHaveValidationErrorFor(q => q.hierarchyType);
+        result.ShouldHaveValidationErrorFor(q => q.HierarchyType);
     }
 }

--- a/wiki/Cache-Query-Results.md
+++ b/wiki/Cache-Query-Results.md
@@ -12,21 +12,21 @@ using IntegratoR.Abstractions.Interfaces.Queries;
 using IntegratoR.OData.FO.Domain.Enums.Dimensions;
 using IntegratoR.OData.FO.Domain.Models.FinancialDimensions;
 
-public record GetDimensionOrdersQuery(string dimensionFormat, DimensionHierarchyType hierarchyType)
+public record GetDimensionOrdersQuery(string DimensionFormat, DimensionHierarchyType HierarchyType)
     : ICacheableQuery<Result<DimensionFormat>>
 {
-    public string CacheKey => $"{nameof(GetDimensionOrdersQuery)}-{dimensionFormat}-{hierarchyType}";
+    public string CacheKey => $"{nameof(GetDimensionOrdersQuery)}-{DimensionFormat}-{HierarchyType}";
 
     public TimeSpan? CacheDuration => TimeSpan.FromMinutes(15);
 
     public string GenerateCacheKey() => CacheKey;
 
-    public object[] GetCacheKeyValues() => [nameof(GetDimensionOrdersQuery), dimensionFormat, hierarchyType];
+    public object[] GetCacheKeyValues() => [nameof(GetDimensionOrdersQuery), DimensionFormat, HierarchyType];
 
     public IReadOnlyDictionary<string, object> GetLoggingContext() => new Dictionary<string, object>
     {
-        { "DimensionFormat", dimensionFormat },
-        { "HierarchyType", hierarchyType.ToString() }
+        { "DimensionFormat", DimensionFormat },
+        { "HierarchyType", HierarchyType.ToString() }
     };
 }
 ```

--- a/wiki/Run-Queries.md
+++ b/wiki/Run-Queries.md
@@ -82,21 +82,21 @@ using IntegratoR.Abstractions.Interfaces.Queries;
 using IntegratoR.OData.FO.Domain.Enums.Dimensions;
 using IntegratoR.OData.FO.Domain.Models.FinancialDimensions;
 
-public record GetDimensionOrdersQuery(string dimensionFormat, DimensionHierarchyType hierarchyType)
+public record GetDimensionOrdersQuery(string DimensionFormat, DimensionHierarchyType HierarchyType)
     : ICacheableQuery<Result<DimensionFormat>>
 {
-    public string CacheKey => $"{nameof(GetDimensionOrdersQuery)}-{dimensionFormat}-{hierarchyType}";
+    public string CacheKey => $"{nameof(GetDimensionOrdersQuery)}-{DimensionFormat}-{HierarchyType}";
 
     public TimeSpan? CacheDuration => TimeSpan.FromMinutes(15);
 
     public string GenerateCacheKey() => CacheKey;
 
-    public object[] GetCacheKeyValues() => [nameof(GetDimensionOrdersQuery), dimensionFormat, hierarchyType];
+    public object[] GetCacheKeyValues() => [nameof(GetDimensionOrdersQuery), DimensionFormat, HierarchyType];
 
     public IReadOnlyDictionary<string, object> GetLoggingContext() => new Dictionary<string, object>
     {
-        { "DimensionFormat", dimensionFormat },
-        { "HierarchyType", hierarchyType.ToString() }
+        { "DimensionFormat", DimensionFormat },
+        { "HierarchyType", HierarchyType.ToString() }
     };
 }
 ```


### PR DESCRIPTION
Third of the fix series. Makes the CQRS write surface internally consistent and adds the missing generic batch handlers.

## Changes
- **`IBatchService<TEntity>`** (new, in Abstractions; `IODataBatchService<T> : IBatchService<T>`) → the new generic **`Create/Update/DeleteBatchCommandHandler<T>`** live in `Application` injecting `IBatchService<T>` (Application keeps its Abstractions-only layering). Closes the consumer-facing gap where `mediator.Send(new CreateBatchCommand<T>(…))` had no handler.
- FO LedgerJournal commands inherit the generic base command types; `IEnumerable→IReadOnlyList` on batch commands (O(1) `Count`, no lazy multiple-enumeration).
- `GetDimensionOrdersQuery` params → PascalCase `DimensionFormat`/`HierarchyType` (+ wiki examples updated); logger-category fix, class rename, readonly/`_service`, primary→explicit ctor, `{Comany}`→`{Company}`.

## Important discovery (tracked follow-up)
FluentValidation's `AddValidatorsFromAssembly` **cannot register open-generic validators**, so generic/derived command validators have **never fired** through the MediatR pipeline — a pre-existing framework gap. PR-C adds the 8 derived FO validators (correct structure, unit-tested directly) but leaves them **dormant** with the limitation documented in-code; the closed-generic registration fix is tracked as backlog (high).

## Verification
- `dotnet build` 0 errors; `dotnet test` **546 passed, 0 failed, 0 skipped** (+12).
- `code-reviewer`: needs-work → both blockers resolved (`+semver: minor` marker; wiki + validator-comment honesty).

## Semver
`+semver: minor` — additive `IBatchService`/batch handlers; the `IReadOnlyList` narrowing + `GetDimensionOrdersQuery` rename are accepted MINOR source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)