### PR TITLE
chore(api): public-API hygiene + dead-code removal + ownership docs (PR-D)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -25,7 +25,7 @@ SampleFunction (host/composition root)
 - **CQRS via MediatR**: Commands and queries are `record` types implementing `ICommand<TResponse>` or `IQuery<TResponse>`.
 - **Generic commands**: `CreateCommand<TEntity>`, `UpdateCommand<TEntity>`, `DeleteCommand<TEntity>` reusable with any `IEntity`.
 - **Batch commands**: `CreateBatchCommand<TEntity>`, `UpdateBatchCommand<TEntity>`, `DeleteBatchCommand<TEntity>` for bulk operations.
-- **Entity extensibility**: F&O entities inherit from `BaseEntity<TKey>` and must implement `GetCompositeKey()` (D365 uses composite keys like `DataAreaId` + business key).
+- **Entity extensibility**: F&O entities inherit from the non-generic `BaseEntity` and must implement `GetCompositeKey()` (D365 uses composite keys like `DataAreaId` + business key). `BaseEntity<TKey>` is `[Obsolete]` (the `TKey` parameter was never used) and is removed next MAJOR.
 - **`ODataFieldAttribute`**: Controls property serialisation — `IgnoreOnCreate`, `IgnoreOnUpdate` for server-generated or read-only fields.
 - **Pipeline order**: Logging -> Validation -> Caching -> Handler (registration order matters in `AddApplicationServices()`).
 - **Each layer has its own `ApplicationDependencyInjection`** class with extension methods for DI setup.
@@ -48,5 +48,9 @@ The codebase uses **two JSON serialisers** and `Result<T>` needs custom converte
 **Adding a new Newtonsoft code path:** the global `JsonConvert.DefaultSettings` hook covers you automatically.
 
 **Test the wiring, not just the converter:** unit tests on a converter in isolation don't catch wiring bugs. Use real `MemoryDistributedCache` (`DistributedCacheServiceResultRoundTripTests`) and real `JsonDataConverter` (`DurableTaskJsonDataConverterResultTests`) to prove the registered options reach the actual code path. Cross-serialiser compatibility is pinned by `tests/IntegratoR.Abstractions.Tests/Common/Results/CrossSerializerCompatibilityTests.cs`.
+
+## Accepted Trade-offs
+
+- **`IEntity.GetLoggingContext()` couples telemetry to the domain contract.** `IEntity` declares `IReadOnlyDictionary<string, object> GetLoggingContext()` directly, so every domain entity carries a structured-logging concern on its core interface. Extracting it to a dedicated logging interface (e.g. `ILoggable` / the existing `IContext`) is **deferred**: it is a MAJOR-breaking change to a packable interface for low value today. The future-MAJOR migration path is: introduce a separate logging interface, move `GetLoggingContext()` there, have `BaseEntity` implement both, deprecate the `IEntity` member for one MINOR, then remove it in the next MAJOR. Recorded here so it is not re-litigated; no code change is made now.
 
 See `odata-conventions.md` for ODataSettings structure and entity patterns.

--- a/IntegratoR.Abstractions/Domain/Entities/BaseEntity.cs
+++ b/IntegratoR.Abstractions/Domain/Entities/BaseEntity.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using IntegratoR.Abstractions.Interfaces.Entity;
 using IntegratoR.Abstractions.Interfaces.Telemetry;
@@ -6,17 +7,24 @@ namespace IntegratoR.Abstractions.Domain.Entities;
 
 /// <summary>
 /// Provides a foundational abstract base class for domain entities within the solution.
-/// It establishes a common contract for entity identification by providing a generic primary key.
+/// It establishes a common contract for entity identification via a composite key and for
+/// structured-logging context capture.
 /// </summary>
-/// <typeparam name="TKey">The data type of the entity's primary key (e.g., <see cref="long"/>, <see cref="string"/>, <see cref="Guid"/>).</typeparam>
 /// <remarks>
 /// In a Domain-Driven Design (DDD) context, classes deriving from <c>BaseEntity</c> represent objects
 /// defined not by their attributes, but by their thread of continuity and identity. This base class
 /// helps decouple the core domain model from the data persistence layer,
 /// promoting a cleaner and more maintainable architecture.
 /// </remarks>
-public abstract class BaseEntity<TKey> : IEntity, IContext
+public abstract class BaseEntity : IEntity, IContext
 {
+    /// <summary>
+    /// Caches, per concrete entity <see cref="Type"/>, the public readable non-indexed properties used
+    /// by <see cref="GetLoggingContext"/>. Reflection over a type's property set is invariant, so the
+    /// discovery is performed once per type and reused on every subsequent call.
+    /// </summary>
+    private static readonly ConcurrentDictionary<Type, PropertyInfo[]> LoggingPropertyCache = new();
+
     /// <summary>
     /// Gets the composite primary key that uniquely identifies this entity.
     /// </summary>
@@ -25,8 +33,7 @@ public abstract class BaseEntity<TKey> : IEntity, IContext
     /// </returns>
     /// <remarks>
     /// This method is essential for entities with composite keys. It abstracts the specific properties
-    /// that constitute the key, enabling generic patterns (like the Repository or Specification pattern)
-    /// to retrieve or process entities by their complete key.
+    /// that constitute the key, enabling generic patterns to retrieve or process entities by their complete key.
     ///
     /// In D365 F&O, many entities feature composite keys, which often include a <c>DataAreaId</c> in combination
     /// with other fields (e.g., <c>SalesOrderNumber</c>, <c>JournalBatchNumber</c>).
@@ -41,15 +48,34 @@ public abstract class BaseEntity<TKey> : IEntity, IContext
     /// </returns>
     /// <remarks>
     /// This method uses reflection to iterate over all public, readable instance properties of the derived class.
+    /// The per-type property set is cached so the reflection cost is paid once per concrete type.
     /// It is particularly useful for structured logging, where an object's state is captured as key-value pairs.
     /// Properties whose value is <see langword="null"/> are replaced with a new <see cref="object"/> to avoid null reference issues in logging contexts.
     /// Indexed properties are excluded from the output.
     /// </remarks>
     public virtual IReadOnlyDictionary<string, object> GetLoggingContext()
     {
-        return this.GetType()
-            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Where(p => p.CanRead && p.GetIndexParameters().Length == 0)
-            .ToDictionary(p => p.Name, p => p.GetValue(this) ?? new object());
+        PropertyInfo[] props = LoggingPropertyCache.GetOrAdd(
+            GetType(),
+            static t => t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.CanRead && p.GetIndexParameters().Length == 0)
+                .ToArray());
+
+        return props.ToDictionary(p => p.Name, p => p.GetValue(this) ?? new object());
     }
+}
+
+/// <summary>
+/// Provides a foundational abstract base class for domain entities, parameterised by a primary-key type.
+/// </summary>
+/// <typeparam name="TKey">The data type of the entity's primary key (e.g., <see cref="long"/>, <see cref="string"/>, <see cref="Guid"/>).</typeparam>
+/// <remarks>
+/// <para>
+/// The <typeparamref name="TKey"/> type parameter is unused — the contract is expressed entirely through
+/// <see cref="BaseEntity.GetCompositeKey"/>. Derive from the non-generic <see cref="BaseEntity"/> instead.
+/// </para>
+/// </remarks>
+[Obsolete("since v1.4.0; the TKey type parameter is unused — derive from the non-generic BaseEntity instead; removed next MAJOR")]
+public abstract class BaseEntity<TKey> : BaseEntity
+{
 }

--- a/IntegratoR.Abstractions/Interfaces/Queries/ICacheableQuery.cs
+++ b/IntegratoR.Abstractions/Interfaces/Queries/ICacheableQuery.cs
@@ -29,8 +29,8 @@ public interface ICacheableQuery<TResponse> : IQuery<TResponse>
     /// Gets the unique key used to store and retrieve the query's response from the cache.
     /// </summary>
     /// <remarks>
-    /// This is typically implemented as a get-only property that calls <see cref="GenerateCacheKey"/>
-    /// to ensure the key is always derived consistently from the query's parameters.
+    /// The caching pipeline (<c>CachingBehaviour</c>) reads this property directly. Implement it as a
+    /// get-only property that derives the key consistently from the query's parameters.
     /// </remarks>
     string CacheKey { get; }
 
@@ -48,10 +48,9 @@ public interface ICacheableQuery<TResponse> : IQuery<TResponse>
     /// </summary>
     /// <returns>An array of objects that will be used to generate the cache key.</returns>
     /// <remarks>
-    /// This method is crucial for cache correctness. It forces the developer to explicitly select
-    /// the properties of the query that affect its result (e.g., an entity ID, a filter string,
-    /// a company code), ensuring that two different queries produce two different cache keys.
+    /// Not used by the caching pipeline, which reads <see cref="CacheKey"/> directly.
     /// </remarks>
+    [Obsolete("since v1.4.0; CachingBehaviour uses CacheKey directly; removed next MAJOR")]
     object[] GetCacheKeyValues();
 
     /// <summary>
@@ -59,10 +58,8 @@ public interface ICacheableQuery<TResponse> : IQuery<TResponse>
     /// </summary>
     /// <returns>A unique string to be used as the cache key.</returns>
     /// <remarks>
-    /// A recommended implementation is to combine a static prefix (like the query name) with a
-    /// serialized (e.g., JSON) representation of the objects from <see cref="GetCacheKeyValues"/>.
-    /// This creates a key that is both unique and human-readable for debugging purposes.
-    /// Example: "CustomerById:[\"C-123\",\"USMF\"]".
+    /// Not used by the caching pipeline, which reads <see cref="CacheKey"/> directly.
     /// </remarks>
+    [Obsolete("since v1.4.0; CachingBehaviour uses CacheKey directly; removed next MAJOR")]
     string GenerateCacheKey();
 }

--- a/IntegratoR.Abstractions/Interfaces/Services/IService.cs
+++ b/IntegratoR.Abstractions/Interfaces/Services/IService.cs
@@ -5,18 +5,17 @@ using IntegratoR.Abstractions.Interfaces.Entity;
 namespace IntegratoR.Abstractions.Interfaces.Services;
 
 /// <summary>
-/// Defines a generic repository pattern for data access, abstracting CRUD (Create, Read, Update, Delete)
-/// and query operations for a specific entity type.
+/// Defines the generic data-access abstraction for an entity type, exposing CRUD (Create, Read,
+/// Update, Delete) and query operations.
 /// </summary>
-/// <typeparam name="TEntity">The type of the entity, which must implement <see cref="IEntity{TKey}"/>.</typeparam>
-/// <typeparam name="TKey">The type of the entity's primary key.</typeparam>
+/// <typeparam name="TEntity">The type of the entity, which must implement <see cref="IEntity"/>.</typeparam>
 /// <remarks>
-/// While named <c>IService</c>, this interface's role is that of a **Repository**. It isolates the application
-/// and domain layers from the data source's implementation details.
+/// This interface IS the data-access abstraction for an entity type; do not wrap it in an additional
+/// repository layer. It isolates the application and domain layers from the data source's
+/// implementation details.
 ///
-/// A concrete implementation (e.g., <c>ODataService&lt;TEntity, TKey&gt;</c>) would be responsible for
-/// translating these method calls into specific OData HTTP requests against a OData endpoint,
-/// typically using a library.
+/// A concrete implementation (e.g., <c>ODataService&lt;TEntity&gt;</c>) translates these method calls
+/// into specific OData HTTP requests against an OData endpoint.
 /// </remarks>
 public interface IService<TEntity> where TEntity : IEntity
 {

--- a/IntegratoR.CodeGen/Services/EntityGenerator.cs
+++ b/IntegratoR.CodeGen/Services/EntityGenerator.cs
@@ -6,12 +6,12 @@ namespace IntegratoR.CodeGen.Services;
 
 /// <summary>
 /// Generates C# entity source files from parsed CSDL models.
-/// Produces partial classes inheriting from <c>BaseEntity&lt;string&gt;</c> with full
+/// Produces partial classes inheriting from <c>BaseEntity</c> with full
 /// OData attribute decoration matching D365 F&amp;O metadata.
 /// </summary>
 public class EntityGenerator
 {
-    private const string DefaultBaseClass = "BaseEntity<string>";
+    private const string DefaultBaseClass = "BaseEntity";
 
     private readonly string _namespace;
     private readonly string _baseClass;

--- a/IntegratoR.OData.FO/Domain/Entities/Dimensions/DimensionIntegrationFormat.cs
+++ b/IntegratoR.OData.FO/Domain/Entities/Dimensions/DimensionIntegrationFormat.cs
@@ -13,7 +13,7 @@ namespace IntegratoR.OData.FO.Domain.Entities.Dimensions;
 /// (e.g., "618160-001-023") should be constructed or deconstructed, mapping them to the correct dimension format in D365 F&O.
 /// </summary>
 [Table("DimensionIntegrationFormats")]
-public class DimensionIntegrationFormat : BaseEntity<string>
+public class DimensionIntegrationFormat : BaseEntity
 {
     /// <summary>
     /// The unique name of the dimension format configuration. This serves as the primary identifier for the record.

--- a/IntegratoR.OData.FO/Domain/Entities/Dimensions/DimensionParameters.cs
+++ b/IntegratoR.OData.FO/Domain/Entities/Dimensions/DimensionParameters.cs
@@ -12,7 +12,7 @@ namespace IntegratoR.OData.FO.Domain.Entities.Dimensions;
 /// ensuring consistent processing across different functions.
 /// </summary>
 [Table("DimensionParameters")]
-public class DimensionParameters : BaseEntity<int>
+public class DimensionParameters : BaseEntity
 {
     /// <summary>
     /// The primary key for the parameter record, used to uniquely identify this set of dimension settings.

--- a/IntegratoR.OData.FO/Domain/Entities/LedgerJournal/LedgerJournalHeader.cs
+++ b/IntegratoR.OData.FO/Domain/Entities/LedgerJournal/LedgerJournalHeader.cs
@@ -15,7 +15,7 @@ namespace IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
 /// It acts as a container for a batch of journal lines, defining common properties and controlling the overall posting process.
 /// </summary>
 [Table("LedgerJournalHeaders")]
-public class LedgerJournalHeader : BaseEntity<string>
+public class LedgerJournalHeader : BaseEntity
 {
     /// <summary>
     /// The unique identifier of the legal entity (company) in which the journal is created.
@@ -23,6 +23,7 @@ public class LedgerJournalHeader : BaseEntity<string>
     /// </summary>
     [Key]
     [JsonPropertyName("dataAreaId")]
+    [ODataField(IsRequired = true)]
     public required string DataAreaId { get; set; }
 
     /// <summary>
@@ -68,16 +69,14 @@ public class LedgerJournalHeader : BaseEntity<string>
     public virtual NoYes IsPosted { get; set; }
 
     /// <summary>
-    // A read-only, system-calculated field showing the total of all debit amounts from the journal lines.
+    /// A read-only, system-calculated field showing the total of all debit amounts from the journal lines.
     /// </summary>
-    [Required]
     [JsonPropertyName("JournalTotalDebit")]
     public virtual decimal JournalTotalDebit { get; set; }
 
     /// <summary>
     /// A read-only, system-calculated field showing the total of all credit amounts from the journal lines.
     /// </summary>
-    [Required]
     [JsonPropertyName("JournalTotalCredit")]
     public virtual decimal JournalTotalCredit { get; set; }
 

--- a/IntegratoR.OData.FO/Domain/Entities/LedgerJournal/LedgerJournalLine.cs
+++ b/IntegratoR.OData.FO/Domain/Entities/LedgerJournal/LedgerJournalLine.cs
@@ -14,14 +14,14 @@ namespace IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
 /// It is used to record debit or credit transactions against various account types such as Ledger, Customer, Vendor, etc.
 /// </summary>
 [Table("LedgerJournalLines")]
-public class LedgerJournalLine : BaseEntity<string>
+public class LedgerJournalLine : BaseEntity
 {
     /// <summary>
     /// The unique identifier of the legal entity (company) in which the journal line is created.
     /// Part of the composite primary key.
     /// </summary>
     [Key]
-    [Required]
+    [ODataField(IsRequired = true)]
     [JsonPropertyName("dataAreaId")]
     public required string DataAreaId { get; set; }
 
@@ -30,7 +30,7 @@ public class LedgerJournalLine : BaseEntity<string>
     /// Part of the composite primary key.
     /// </summary>
     [Key]
-    [Required]
+    [ODataField(IsRequired = true)]
     [JsonPropertyName("JournalBatchNumber")]
     public required string JournalBatchNumber { get; set; }
 
@@ -40,7 +40,6 @@ public class LedgerJournalLine : BaseEntity<string>
     /// Part of the composite primary key.
     /// </summary>
     [Key]
-    [Required]
     [JsonPropertyName("LineNumber")]
     [ODataField(IgnoreOnCreate = true)]
     public decimal LineNumber { get; set; }
@@ -48,7 +47,6 @@ public class LedgerJournalLine : BaseEntity<string>
     /// <summary>
     /// The primary account for the transaction, combining the main account and financial dimensions.
     /// </summary>
-    [Required]
     [JsonPropertyName("AccountDisplayValue")]
     [ODataField(IgnoreOnCreate = true)]
     public virtual required string AccountDisplayValue { get; set; }
@@ -63,21 +61,21 @@ public class LedgerJournalLine : BaseEntity<string>
     /// <summary>
     /// The debit amount of the transaction in the transaction currency. Must be zero if CreditAmount has a value.
     /// </summary>
-    [Required]
+    [ODataField(IsRequired = true)]
     [JsonPropertyName("DebitAmount")]
     public virtual decimal DebitAmount { get; set; }
 
     /// <summary>
     /// The credit amount of the transaction in the transaction currency. Must be zero if DebitAmount has a value.
     /// </summary>
-    [Required]
+    [ODataField(IsRequired = true)]
     [JsonPropertyName("CreditAmount")]
     public virtual decimal CreditAmount { get; set; }
 
     /// <summary>
     /// The three-letter ISO code for the currency of the transaction.
     /// </summary>
-    [Required]
+    [ODataField(IsRequired = true)]
     [JsonPropertyName("CurrencyCode")]
     public virtual required string CurrencyCode { get; set; }
 
@@ -105,7 +103,6 @@ public class LedgerJournalLine : BaseEntity<string>
     /// <summary>
     /// The transaction date, which determines the posting date for the financial entry.
     /// </summary>
-    [Required]
     [JsonPropertyName("TransDate")]
     [ODataField(IgnoreOnCreate = true)]
     public virtual required DateTimeOffset TransDate { get; set; }
@@ -142,7 +139,6 @@ public class LedgerJournalLine : BaseEntity<string>
     /// <summary>
     /// The due date for the transaction, primarily used for customer and vendor account types to calculate payment terms.
     /// </summary>
-    [Required]
     [JsonPropertyName("DueDate")]
     [ODataField(IgnoreOnCreate = true)]
     public virtual DateTimeOffset DueDate { get; set; }
@@ -150,7 +146,6 @@ public class LedgerJournalLine : BaseEntity<string>
     /// <summary>
     /// The document date, often representing the date on an external document like a vendor invoice.
     /// </summary>
-    [Required]
     [JsonPropertyName("DocumentDate")]
     [ODataField(IgnoreOnCreate = true)]
     public virtual DateTimeOffset DocumentDate { get; set; }
@@ -193,7 +188,6 @@ public class LedgerJournalLine : BaseEntity<string>
     /// <summary>
     /// The exchange rate between the transaction currency and the accounting currency.
     /// </summary>
-    [Required]
     [JsonPropertyName("ExchRate")]
     [ODataField(IgnoreOnCreate = true)]
     public virtual decimal ExchRate { get; set; }
@@ -236,7 +230,6 @@ public class LedgerJournalLine : BaseEntity<string>
     /// <summary>
     /// The date on which the reversing entry will be posted. This field is mandatory if 'ReverseEntry' is set to Yes.
     /// </summary>
-    [Required]
     [JsonPropertyName("ReverseDate")]
     [ODataField(IgnoreOnCreate = true)]
     public virtual DateTimeOffset ReverseDate { get; set; }

--- a/IntegratoR.OData.FO/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQuery.cs
+++ b/IntegratoR.OData.FO/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQuery.cs
@@ -11,6 +11,9 @@ public record GetDimensionOrdersQuery(string DimensionFormat, DimensionHierarchy
 
     public TimeSpan? CacheDuration => TimeSpan.FromMinutes(15);
 
+    // GenerateCacheKey/GetCacheKeyValues are [Obsolete] on ICacheableQuery but must still be
+    // implemented until the next MAJOR removes the interface members. CachingBehaviour reads CacheKey.
+#pragma warning disable CS0618 // Type or member is obsolete
     public string GenerateCacheKey()
     {
         return CacheKey;
@@ -21,6 +24,7 @@ public record GetDimensionOrdersQuery(string DimensionFormat, DimensionHierarchy
         return new object[] { nameof(GetDimensionOrdersQuery), DimensionFormat, HierarchyType }
         ;
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 
     public IReadOnlyDictionary<string, object> GetLoggingContext()
     {

--- a/IntegratoR.OData.FO/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryHandler.cs
+++ b/IntegratoR.OData.FO/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryHandler.cs
@@ -46,7 +46,7 @@ public class GetDimensionOrdersQueryHandler : IRequestHandler<GetDimensionOrders
         }
         var financialDimensionFormat = dimensionFormats.Value?.FirstOrDefault();
 
-        var dimensionParameters = await _dimensionParametersService.FindAll(cancellationToken).ConfigureAwait(false);
+        var dimensionParameters = await _dimensionParametersService.FindAllAsync(cancellationToken).ConfigureAwait(false);
 
         if (dimensionParameters.IsFailed)
         {

--- a/IntegratoR.OData/Common/Exceptions/ODataBatchException.cs
+++ b/IntegratoR.OData/Common/Exceptions/ODataBatchException.cs
@@ -6,6 +6,7 @@ namespace IntegratoR.OData.Common.Exceptions;
 /// Thrown when one or more operations within an OData batch request fail.
 /// Contains per-entity failure details for diagnostic purposes.
 /// </summary>
+[Obsolete("since v1.4.0; never thrown; batch failures surface via Result<T>; removed next MAJOR")]
 public class ODataBatchException : Exception
 {
     /// <summary>

--- a/IntegratoR.OData/Common/Extensions/ApplicationDependencyInjection.cs
+++ b/IntegratoR.OData/Common/Extensions/ApplicationDependencyInjection.cs
@@ -57,7 +57,6 @@ internal static class ApplicationDependencyInjection
 
         // Register supporting services
         services.AddTransient<ODataAuthenticationHandler>();
-        services.AddSingleton<ODataMetadataProvider>();
 
         // Configure HttpClient with Polly policies
         services.AddHttpClient("ODataClient", (serviceProvider, httpClient) =>
@@ -191,7 +190,13 @@ internal static class ApplicationDependencyInjection
                     });
         });
 
-        // Register repository services
+        // Register the data-access service under each interface it satisfies. These four open-generic
+        // registrations intentionally yield independent ODataService<T> instances per scope — resolving
+        // IService<T>, IODataService<T>, IODataBatchService<T> and IBatchService<T> from the same scope
+        // produces three or four separate instances. This is safe and deliberate: ODataService<T> is
+        // stateless (only readonly injected dependencies plus static per-type caches), so the extra
+        // instances are cheap and observationally identical. A shared-instance forwarder would only be
+        // warranted if mutable per-instance state were ever introduced.
         services.AddScoped(typeof(IntegratoR.Abstractions.Interfaces.Services.IService<>), typeof(ODataService<>));
         services.AddScoped(typeof(IODataService<>), typeof(ODataService<>));
         services.AddScoped(typeof(IODataBatchService<>), typeof(ODataService<>));

--- a/IntegratoR.OData/Common/Filters/IntegratoRODataExpressionTranslator.cs
+++ b/IntegratoR.OData/Common/Filters/IntegratoRODataExpressionTranslator.cs
@@ -12,14 +12,18 @@
 //       $filter=DataAreaId eq 'USMF'
 //   which D365 (case-sensitive) rejects, returning empty results.
 //
-// This translator is structurally a near-copy of PanoramicData's
+// This translator began structurally as a near-copy of PanoramicData's
 //   ODataQueryBuilder.ExpressionParsing.cs and ODataQueryBuilder.LambdaParsing.cs
 // with one targeted change: every read of a property/field MemberInfo.Name is routed through
 // ResolveJsonName(...) which consults [JsonPropertyName] before falling back to MemberInfo.Name.
 //
-// Once the upstream PR (https://github.com/panoramicdata/panoramicdata.odata.client) lands,
-// this file can be deleted and the ODataClientAdapter can revert to passing Expressions
-// directly to PanoramicData.
+// OWNERSHIP
+// ---------
+// This is a PERMANENT, OWNED D365 extension of the PanoramicData parser — not a temporary fork
+// awaiting an upstream merge. It has diverged intentionally (D365 enum literal handling, .NET 10
+// expression-tree workarounds, [JsonPropertyName] resolution including $orderby, and the
+// composite-key write path) and is NOT tracked for deletion. The MIT attribution below is
+// retained; treat this file as first-party source maintained in this repository.
 //
 // ATTRIBUTION
 // -----------

--- a/IntegratoR.OData/Common/Services/ODataExceptionHandler.cs
+++ b/IntegratoR.OData/Common/Services/ODataExceptionHandler.cs
@@ -568,25 +568,13 @@ public class ODataExceptionHandler<TEntity> where TEntity : class, IEntity
     private void LogSuccess(
         OperationContext context,
         TimeSpan elapsed,
-        int? count = null,
         int attemptCount = 1)
     {
         var attemptInfo = attemptCount > 1 ? $" (after {attemptCount} attempts)" : "";
 
-        if (count.HasValue)
-        {
-            _logger.LogInformation(
-                "{Operation} on {EntityType} succeeded in {ElapsedMs}ms{AttemptInfo}. " +
-                "Retrieved {Count} entities",
-                context.OperationName, context.EntityType, elapsed.TotalMilliseconds,
-                attemptInfo, count.Value);
-        }
-        else
-        {
-            _logger.LogInformation(
-                "{Operation} on {EntityType} succeeded in {ElapsedMs}ms{AttemptInfo}",
-                context.OperationName, context.EntityType, elapsed.TotalMilliseconds, attemptInfo);
-        }
+        _logger.LogInformation(
+            "{Operation} on {EntityType} succeeded in {ElapsedMs}ms{AttemptInfo}",
+            context.OperationName, context.EntityType, elapsed.TotalMilliseconds, attemptInfo);
     }
 }
 

--- a/IntegratoR.OData/Common/Services/ODataMetadataProvider.cs
+++ b/IntegratoR.OData/Common/Services/ODataMetadataProvider.cs
@@ -13,6 +13,7 @@ namespace IntegratoR.OData.Common.Services;
 /// - Enables offline development
 /// - Metadata changes are version-controlled
 /// </summary>
+[Obsolete("since v1.4.0; unused — D365 $metadata is not loaded at runtime; removed next MAJOR")]
 public class ODataMetadataProvider
 {
     private readonly ILogger<ODataMetadataProvider> _logger;

--- a/IntegratoR.OData/Common/Services/ODataService.cs
+++ b/IntegratoR.OData/Common/Services/ODataService.cs
@@ -244,7 +244,7 @@ public class ODataService<TEntity> : IODataService<TEntity>, IODataBatchService<
     }
 
     /// <inheritdoc />
-    public Task<Result<IEnumerable<TEntity>>> FindAll(CancellationToken cancellationToken = default)
+    public Task<Result<IEnumerable<TEntity>>> FindAllAsync(CancellationToken cancellationToken = default)
     {
         return _exceptionHandler.ExecuteCollectionAsync(
             operationName: "FindAll",
@@ -253,6 +253,11 @@ public class ODataService<TEntity> : IODataService<TEntity>, IODataBatchService<
                 .ConfigureAwait(false),
             cancellationToken: cancellationToken);
     }
+
+    /// <inheritdoc />
+    [Obsolete("since v1.4.0; use FindAllAsync; removed next MAJOR")]
+    public Task<Result<IEnumerable<TEntity>>> FindAll(CancellationToken cancellationToken = default)
+        => FindAllAsync(cancellationToken);
 
     /// <inheritdoc />
     public Task<Result<int>> CountAsync(

--- a/IntegratoR.OData/Interfaces/Services/IODataService.cs
+++ b/IntegratoR.OData/Interfaces/Services/IODataService.cs
@@ -16,11 +16,10 @@ using IntegratoR.Abstractions.Interfaces.Services;
 namespace IntegratoR.OData.Interfaces.Services;
 
 /// <summary>
-/// Extends the generic <see cref="IService{TEntity, TKey}"/> with features specific to the OData protocol,
+/// Extends the generic <see cref="IService{TEntity}"/> with features specific to the OData protocol,
 /// such as expanding related entities, selecting specific fields, ordering, and paging.
 /// </summary>
 /// <typeparam name="TEntity">The type of the entity being queried.</typeparam>
-/// <typeparam name="TKey">The type of the entity's primary key.</typeparam>
 public interface IODataService<TEntity> : IService<TEntity> where TEntity : IEntity
 {
     /// <summary>
@@ -73,12 +72,26 @@ public interface IODataService<TEntity> : IService<TEntity> where TEntity : IEnt
     /// <summary>
     /// Asynchronously retrieves all entities of the specified type from the data set.
     /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A <see cref="Result{T}"/> containing the complete collection of entities.</returns>
     /// <remarks>
     /// <b>Caution:</b> Use this method judiciously on data entities that may contain a large
     /// number of records, as it can result in significant network payload and impact performance.
     /// Consider using filtering or paging (`QueryAsync`) where possible.
     /// </remarks>
+    Task<Result<IEnumerable<TEntity>>> FindAllAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously retrieves all entities of the specified type from the data set.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A <see cref="Result{T}"/> containing the complete collection of entities.</returns>
+    /// <remarks>
+    /// <b>Caution:</b> Use this method judiciously on data entities that may contain a large
+    /// number of records, as it can result in significant network payload and impact performance.
+    /// Consider using filtering or paging (`QueryAsync`) where possible.
+    /// </remarks>
+    [Obsolete("since v1.4.0; use FindAllAsync; removed next MAJOR")]
     Task<Result<IEnumerable<TEntity>>> FindAll(CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -12,16 +12,18 @@ licenses through the package manager).
 `ODataQueryBuilder.ExpressionParsing.cs` and `ODataQueryBuilder.LambdaParsing.cs` in
 PanoramicData.OData.Client (https://github.com/panoramicdata/panoramicdata.odata.client).
 
-The structural code is a near-copy of the upstream parser with one targeted modification:
-each read of a `MemberInfo.Name` (for entity property paths) is routed through a
-`ResolveJsonName` helper that consults `[System.Text.Json.Serialization.JsonPropertyName]`
-before falling back to the CLR member name. This adds attribute-based property name
-mapping to the filter / select / expand path resolution, which the upstream library does
-not currently support.
+The structural code began as a near-copy of the upstream parser. Each read of a
+`MemberInfo.Name` (for entity property paths) is routed through a `ResolveJsonName` helper
+that consults `[System.Text.Json.Serialization.JsonPropertyName]` before falling back to
+the CLR member name, adding attribute-based property name mapping to the filter / select /
+expand / orderby path resolution.
 
-When the upstream PR adding `[JsonPropertyName]` support is merged and released,
-`IntegratoRODataExpressionTranslator` can be deleted and `ODataClientAdapter` can revert
-to passing LINQ expressions directly to PanoramicData.
+`IntegratoRODataExpressionTranslator` is a **permanent, owned D365 extension** of the
+PanoramicData parser, not a temporary fork awaiting an upstream merge. The MIT attribution
+below is retained, but the translator has diverged intentionally from upstream (D365 enum
+literal handling, .NET 10 expression-tree workarounds, `[JsonPropertyName]` resolution, and
+the composite-key write path) and is **not tracked for deletion**. Treat it as first-party
+source maintained in this repository.
 
 ```
 MIT License

--- a/tests/IntegratoR.Abstractions.Tests/Domain/Entities/BaseEntityNonGenericTests.cs
+++ b/tests/IntegratoR.Abstractions.Tests/Domain/Entities/BaseEntityNonGenericTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using IntegratoR.Abstractions.Domain.Entities;
+using Xunit;
+
+namespace IntegratoR.Abstractions.Tests.Domain.Entities;
+
+/// <summary>
+/// Unit tests proving the NEW non-generic <see cref="BaseEntity"/> behaves identically to the
+/// (now obsolete) generic <c>BaseEntity&lt;TKey&gt;</c> for <c>GetCompositeKey()</c> and
+/// <c>GetLoggingContext()</c>.
+/// </summary>
+public sealed class BaseEntityNonGenericTests
+{
+    /// <summary>
+    /// A composite-key entity inheriting the non-generic <see cref="BaseEntity"/> directly.
+    /// </summary>
+    private sealed class NonGenericCompositeEntity : BaseEntity
+    {
+        /// <summary>Gets or sets the data area (first key component).</summary>
+        public required string DataAreaId { get; set; }
+
+        /// <summary>Gets or sets the business key (second key component).</summary>
+        public required string DocumentNumber { get; set; }
+
+        /// <summary>Gets or sets a non-key descriptive field.</summary>
+        public string? Description { get; set; }
+
+        /// <inheritdoc/>
+        public override object[] GetCompositeKey() => [DataAreaId, DocumentNumber];
+    }
+
+    /// <summary>
+    /// Verifies <c>GetCompositeKey()</c> returns the expected ordered key array.
+    /// </summary>
+    [Fact]
+    public void GetCompositeKey_ReturnsExpectedOrderedArray()
+    {
+        // Arrange
+        var entity = new NonGenericCompositeEntity
+        {
+            DataAreaId = "USMF",
+            DocumentNumber = "DOC-001",
+            Description = "ignored for key"
+        };
+
+        // Act
+        object[] key = entity.GetCompositeKey();
+
+        // Assert
+        key.Should().HaveCount(2);
+        key[0].Should().Be("USMF");
+        key[1].Should().Be("DOC-001");
+    }
+
+    /// <summary>
+    /// Verifies <c>GetLoggingContext()</c> contains the entity's public properties (inherited from
+    /// the non-generic base) with their values.
+    /// </summary>
+    [Fact]
+    public void GetLoggingContext_ContainsPublicProperties()
+    {
+        // Arrange
+        var entity = new NonGenericCompositeEntity
+        {
+            DataAreaId = "USMF",
+            DocumentNumber = "DOC-001",
+            Description = "ledger import"
+        };
+
+        // Act
+        var context = entity.GetLoggingContext();
+
+        // Assert
+        context.Should().ContainKey("DataAreaId").WhoseValue.Should().Be("USMF");
+        context.Should().ContainKey("DocumentNumber").WhoseValue.Should().Be("DOC-001");
+        context.Should().ContainKey("Description").WhoseValue.Should().Be("ledger import");
+    }
+}

--- a/tests/IntegratoR.Abstractions.Tests/Domain/Entities/BaseEntityTests.cs
+++ b/tests/IntegratoR.Abstractions.Tests/Domain/Entities/BaseEntityTests.cs
@@ -5,15 +5,15 @@ using Xunit;
 namespace IntegratoR.Abstractions.Tests.Domain.Entities;
 
 /// <summary>
-/// Unit tests for <see cref="BaseEntity{TKey}"/> covering <c>GetLoggingContext()</c>
-/// and <c>GetCompositeKey()</c> behaviours.
+/// Unit tests for <see cref="BaseEntity"/> covering <c>GetLoggingContext()</c>
+/// (including the per-type reflection cache) and <c>GetCompositeKey()</c> behaviours.
 /// </summary>
 public sealed class BaseEntityTests
 {
     /// <summary>
     /// A local test entity with multiple public properties for logging context tests.
     /// </summary>
-    private sealed class AllPropertiesEntity : BaseEntity<string>
+    private sealed class AllPropertiesEntity : BaseEntity
     {
         /// <summary>Gets or sets the identifier.</summary>
         public required string Id { get; set; }
@@ -31,7 +31,7 @@ public sealed class BaseEntityTests
     /// <summary>
     /// A local test entity with a null-valued property to verify null replacement behaviour.
     /// </summary>
-    private sealed class NullPropertyEntity : BaseEntity<string>
+    private sealed class NullPropertyEntity : BaseEntity
     {
         /// <summary>Gets or sets the identifier.</summary>
         public required string Id { get; set; }
@@ -46,7 +46,7 @@ public sealed class BaseEntityTests
     /// <summary>
     /// A local test entity with an indexed property to verify indexer exclusion.
     /// </summary>
-    private sealed class IndexedPropertyEntity : BaseEntity<string>
+    private sealed class IndexedPropertyEntity : BaseEntity
     {
         private readonly Dictionary<int, string> _data = [];
 
@@ -67,7 +67,7 @@ public sealed class BaseEntityTests
     /// <summary>
     /// A local test entity with no public instance properties beyond the base class contract.
     /// </summary>
-    private sealed class NoPublicPropertiesEntity : BaseEntity<string>
+    private sealed class NoPublicPropertiesEntity : BaseEntity
     {
         /// <inheritdoc/>
         public override object[] GetCompositeKey() => ["key"];
@@ -76,7 +76,7 @@ public sealed class BaseEntityTests
     /// <summary>
     /// A local test entity with composite key for verifying <c>GetCompositeKey()</c>.
     /// </summary>
-    private sealed class CompositeKeyEntity : BaseEntity<string>
+    private sealed class CompositeKeyEntity : BaseEntity
     {
         /// <summary>Gets or sets the identifier.</summary>
         public required string Id { get; set; }
@@ -173,5 +173,26 @@ public sealed class BaseEntityTests
         key.Should().HaveCount(2);
         key[0].Should().Be("id-123");
         key[1].Should().Be("pk-456");
+    }
+
+    /// <summary>
+    /// Verifies that the per-type reflection cache yields a stable property set: two calls on the same
+    /// type (across two different instances) return identical key collections matching the type's
+    /// public readable non-indexed property names.
+    /// </summary>
+    [Fact]
+    public void GetLoggingContext_CalledTwice_UsesCachedPropertySet()
+    {
+        // Arrange
+        var first = new AllPropertiesEntity { Id = "a", Name = "First", Value = 1 };
+        var second = new AllPropertiesEntity { Id = "b", Name = "Second", Value = 2 };
+
+        // Act
+        var firstKeys = first.GetLoggingContext().Keys;
+        var secondKeys = second.GetLoggingContext().Keys;
+
+        // Assert — the cached property set is identical across instances of the same type.
+        secondKeys.Should().BeEquivalentTo(firstKeys);
+        firstKeys.Should().BeEquivalentTo(new[] { "Id", "Name", "Value" });
     }
 }

--- a/tests/IntegratoR.Abstractions.Tests/ObsoleteApiTests.cs
+++ b/tests/IntegratoR.Abstractions.Tests/ObsoleteApiTests.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using FluentAssertions;
+using IntegratoR.Abstractions.Domain.Entities;
+using IntegratoR.Abstractions.Interfaces.Queries;
+using Xunit;
+
+namespace IntegratoR.Abstractions.Tests;
+
+/// <summary>
+/// Reflection pins that assert the deprecation markers on public Abstractions API remain in place.
+/// These guard against premature removal of an <see cref="ObsoleteAttribute"/> before the next MAJOR.
+/// </summary>
+public sealed class ObsoleteApiTests
+{
+    /// <summary>
+    /// <see cref="BaseEntity{TKey}"/> must stay <c>[Obsolete]</c> (the non-generic
+    /// <see cref="BaseEntity"/> is the supported base) until removed next MAJOR.
+    /// </summary>
+    [Fact]
+    public void GenericBaseEntity_IsMarkedObsolete()
+    {
+#pragma warning disable CS0618 // Type or member is obsolete — pinning the deprecation marker
+        ObsoleteAttribute? obsolete = typeof(BaseEntity<>).GetCustomAttribute<ObsoleteAttribute>();
+#pragma warning restore CS0618
+
+        obsolete.Should().NotBeNull();
+        obsolete!.Message.Should().Contain("non-generic BaseEntity");
+    }
+
+    /// <summary>
+    /// <see cref="ICacheableQuery{TResponse}.GenerateCacheKey"/> must stay <c>[Obsolete]</c>;
+    /// the caching pipeline reads <c>CacheKey</c> directly.
+    /// </summary>
+    [Fact]
+    public void GenerateCacheKey_IsMarkedObsolete()
+    {
+        MethodInfo? method = typeof(ICacheableQuery<>).GetMethod(nameof(ICacheableQuery<object>.GenerateCacheKey));
+
+        method.Should().NotBeNull();
+        ObsoleteAttribute? obsolete = method!.GetCustomAttribute<ObsoleteAttribute>();
+        obsolete.Should().NotBeNull();
+        obsolete!.Message.Should().Contain("CacheKey");
+    }
+
+    /// <summary>
+    /// <see cref="ICacheableQuery{TResponse}.GetCacheKeyValues"/> must stay <c>[Obsolete]</c>;
+    /// the caching pipeline reads <c>CacheKey</c> directly.
+    /// </summary>
+    [Fact]
+    public void GetCacheKeyValues_IsMarkedObsolete()
+    {
+        MethodInfo? method = typeof(ICacheableQuery<>).GetMethod(nameof(ICacheableQuery<object>.GetCacheKeyValues));
+
+        method.Should().NotBeNull();
+        ObsoleteAttribute? obsolete = method!.GetCustomAttribute<ObsoleteAttribute>();
+        obsolete.Should().NotBeNull();
+        obsolete!.Message.Should().Contain("CacheKey");
+    }
+}

--- a/tests/IntegratoR.CodeGen.Tests/Services/EntityGeneratorTests.cs
+++ b/tests/IntegratoR.CodeGen.Tests/Services/EntityGeneratorTests.cs
@@ -141,7 +141,7 @@ public class EntityGeneratorTests
 
         string output = GenerateSingleEntity(schema, "MyEntities");
 
-        output.Should().Contain("public partial class MyEntity : BaseEntity<string>");
+        output.Should().Contain("public partial class MyEntity : BaseEntity");
     }
 
     [Fact]

--- a/tests/IntegratoR.Hosting.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/tests/IntegratoR.Hosting.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -716,7 +716,7 @@ public class DummyModelValidator : AbstractValidator<DummyModel>
 /// Used to verify that <c>AddIntegratoR</c> closes the framework's generic CRUD/query
 /// MediatR handlers over entity types supplied via <c>builder.AddConsumerHandlers(assembly)</c>.
 /// </summary>
-public class ConsumerExtendedEntity : BaseEntity<string>
+public class ConsumerExtendedEntity : BaseEntity
 {
     public required string Id { get; set; }
     public string? Name { get; set; }

--- a/tests/IntegratoR.OData.FO.Tests/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryHandlerTests.cs
+++ b/tests/IntegratoR.OData.FO.Tests/Features/Queries/Dimensions/GetDimensionOrder/GetDimensionOrdersQueryHandlerTests.cs
@@ -48,7 +48,7 @@ public class GetDimensionOrdersQueryHandlerTests
             Key = 0,
             DimensionSegmentDelimiter = DimensionSegmentDelimiter.Hyphen
         };
-        _dimParamsService.FindAll(Arg.Any<CancellationToken>())
+        _dimParamsService.FindAllAsync(Arg.Any<CancellationToken>())
             .Returns(Result.Ok<IEnumerable<DimensionParameters>>(new[] { dimParams }));
 
         var dimFormat = new DimensionIntegrationFormat
@@ -115,7 +115,7 @@ public class GetDimensionOrdersQueryHandlerTests
             .Returns(Result.Ok<IEnumerable<DimensionIntegrationFormat>>(new[] { dimFormat }));
 
         var error = new IntegrationError("DimensionParameters.QueryFailed", "Service unavailable", ErrorType.Failure);
-        _dimParamsService.FindAll(Arg.Any<CancellationToken>())
+        _dimParamsService.FindAllAsync(Arg.Any<CancellationToken>())
             .Returns(Result.Fail<IEnumerable<DimensionParameters>>(error));
 
         var query = new GetDimensionOrdersQuery(
@@ -144,7 +144,7 @@ public class GetDimensionOrdersQueryHandlerTests
             Key = 0,
             DimensionSegmentDelimiter = DimensionSegmentDelimiter.Hyphen
         };
-        _dimParamsService.FindAll(Arg.Any<CancellationToken>())
+        _dimParamsService.FindAllAsync(Arg.Any<CancellationToken>())
             .Returns(Result.Ok<IEnumerable<DimensionParameters>>(new[] { dimParams }));
 
         _dimFormatService.FindAsync(Arg.Any<Expression<Func<DimensionIntegrationFormat, bool>>>(), Arg.Any<CancellationToken>())
@@ -183,7 +183,7 @@ public class GetDimensionOrdersQueryHandlerTests
         _dimFormatService.FindAsync(Arg.Any<Expression<Func<DimensionIntegrationFormat, bool>>>(), Arg.Any<CancellationToken>())
             .Returns(Result.Ok<IEnumerable<DimensionIntegrationFormat>>(new[] { dimFormat }));
 
-        _dimParamsService.FindAll(Arg.Any<CancellationToken>())
+        _dimParamsService.FindAllAsync(Arg.Any<CancellationToken>())
             .Returns(Result.Ok<IEnumerable<DimensionParameters>>(Enumerable.Empty<DimensionParameters>()));
 
         var query = new GetDimensionOrdersQuery(
@@ -211,7 +211,7 @@ public class GetDimensionOrdersQueryHandlerTests
             Key = 0,
             DimensionSegmentDelimiter = DimensionSegmentDelimiter.Hyphen
         };
-        _dimParamsService.FindAll(Arg.Any<CancellationToken>())
+        _dimParamsService.FindAllAsync(Arg.Any<CancellationToken>())
             .Returns(Result.Ok<IEnumerable<DimensionParameters>>(new[] { dimParams }));
 
         var dimFormat = new DimensionIntegrationFormat

--- a/tests/IntegratoR.OData.Tests/Common/Extensions/ApplicationDependencyInjectionTests.cs
+++ b/tests/IntegratoR.OData.Tests/Common/Extensions/ApplicationDependencyInjectionTests.cs
@@ -191,10 +191,11 @@ public class ApplicationDependencyInjectionTests
     }
 
     /// <summary>
-    /// Verifies that ODataMetadataProvider is registered as Singleton.
+    /// Verifies that the obsolete, unused <see cref="ODataMetadataProvider"/> is NOT registered.
+    /// Its DI registration was removed (the type is dead at runtime and removed next MAJOR).
     /// </summary>
     [Fact]
-    public void AddODataClient_RegistersMetadataProviderAsSingleton()
+    public void AddODataClient_DoesNotRegisterObsoleteMetadataProvider()
     {
         // Arrange
         var services = new ServiceCollection();
@@ -203,11 +204,12 @@ public class ApplicationDependencyInjectionTests
         services.AddODataClient(options => options.Url = "https://test.example.com");
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete — asserting the type is absent
         var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(ODataMetadataProvider));
+#pragma warning restore CS0618
 
         // Assert
-        descriptor.Should().NotBeNull();
-        descriptor!.Lifetime.Should().Be(ServiceLifetime.Singleton);
+        descriptor.Should().BeNull();
     }
 
     /// <summary>

--- a/tests/IntegratoR.OData.Tests/Common/Services/ODataClientAdapterCompositeKeyWriteTests.cs
+++ b/tests/IntegratoR.OData.Tests/Common/Services/ODataClientAdapterCompositeKeyWriteTests.cs
@@ -303,7 +303,7 @@ public sealed class ODataClientAdapterCompositeKeyWriteTests : IDisposable
     /// take a dependency on <c>IntegratoR.OData.FO</c>.
     /// </summary>
     [Table("LedgerJournalHeaders")]
-    public sealed class TestJournalHeader : BaseEntity<string>
+    public sealed class TestJournalHeader : BaseEntity
     {
         [Key]
         [JsonPropertyName("dataAreaId")]

--- a/tests/IntegratoR.OData.Tests/Common/Services/ODataMetadataProviderTests.cs
+++ b/tests/IntegratoR.OData.Tests/Common/Services/ODataMetadataProviderTests.cs
@@ -8,6 +8,10 @@ using Xunit;
 
 namespace IntegratoR.OData.Tests.Common.Services;
 
+// ODataMetadataProvider is [Obsolete] (unused at runtime, removed next MAJOR). These tests are
+// retained for coverage until the type is removed; suppress CS0618 for the type references here.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 /// <summary>
 /// Tests for <see cref="ODataMetadataProvider"/> using real temp files.
 /// </summary>
@@ -170,3 +174,5 @@ public class ODataMetadataProviderTests : IDisposable
         secondResult.Should().BeFailed("the cache was cleared and the file was deleted");
     }
 }
+
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/tests/IntegratoR.OData.Tests/Common/Services/ODataServiceCompositeKeyTests.cs
+++ b/tests/IntegratoR.OData.Tests/Common/Services/ODataServiceCompositeKeyTests.cs
@@ -96,7 +96,7 @@ public sealed class ODataServiceCompositeKeyTests
     /// ordering test can assert deterministic key-to-value zipping.
     /// </summary>
     [Table("ReverseKeyEntities")]
-    public sealed class ReverseKeyEntity : BaseEntity<string>
+    public sealed class ReverseKeyEntity : BaseEntity
     {
         [Key]
         [JsonPropertyName("first")]
@@ -114,7 +114,7 @@ public sealed class ODataServiceCompositeKeyTests
     /// used to exercise the null-key and count-mismatch Validation failures.
     /// </summary>
     [Table("TwoKeyEntities")]
-    public sealed class TwoKeyEntity : BaseEntity<string>
+    public sealed class TwoKeyEntity : BaseEntity
     {
         [Key]
         [JsonPropertyName("first")]

--- a/tests/IntegratoR.OData.Tests/Common/Services/ODataServiceTests.cs
+++ b/tests/IntegratoR.OData.Tests/Common/Services/ODataServiceTests.cs
@@ -19,7 +19,7 @@ namespace IntegratoR.OData.Tests.Common.Services;
 /// A test entity with a <see cref="JsonIgnoreAttribute"/> decorated property to verify
 /// that <see cref="ODataService{TEntity}"/> excludes such properties from the create payload.
 /// </summary>
-public class TestEntityWithJsonIgnore : BaseEntity<string>
+public class TestEntityWithJsonIgnore : BaseEntity
 {
     /// <summary>Gets or sets the primary key.</summary>
     public required string Id { get; set; }
@@ -327,10 +327,10 @@ public class ODataServiceTests
     }
 
     /// <summary>
-    /// Verifies that FindAll returns a success result with all entities.
+    /// Verifies that FindAllAsync returns a success result with all entities.
     /// </summary>
     [Fact]
-    public async Task FindAll_ReturnsSuccessWithAllEntities()
+    public async Task FindAllAsync_ReturnsSuccessWithAllEntities()
     {
         // Arrange
         var entities = new[] { TestEntityBuilder.Default().Build(), TestEntityBuilder.Default().Build() };
@@ -346,7 +346,36 @@ public class ODataServiceTests
             .Returns(entities);
 
         // Act
+        var result = await _sut.FindAllAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().BeSuccessful();
+        result.Value.Should().HaveCount(2);
+    }
+
+    /// <summary>
+    /// Verifies that the obsolete <c>FindAll</c> still works (delegating to <c>FindAllAsync</c>).
+    /// </summary>
+    [Fact]
+    public async Task FindAll_Obsolete_StillReturnsEntities()
+    {
+        // Arrange
+        var entities = new[] { TestEntityBuilder.Default().Build(), TestEntityBuilder.Default().Build() };
+        _client.FindEntriesAsync<TestEntity>(
+            Arg.Any<string>(),
+            Arg.Any<Expression<Func<TestEntity, bool>>?>(),
+            Arg.Any<Expression<Func<TestEntity, object>>?>(),
+            Arg.Any<Expression<Func<TestEntity, object>>?>(),
+            Arg.Any<IReadOnlyList<(Expression<Func<TestEntity, object>> KeySelector, bool Descending)>?>(),
+            Arg.Any<int?>(),
+            Arg.Any<int?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(entities);
+
+        // Act
+#pragma warning disable CS0618 // Type or member is obsolete — proving the obsolete overload still works
         var result = await _sut.FindAll(CancellationToken.None);
+#pragma warning restore CS0618
 
         // Assert
         result.Should().BeSuccessful();

--- a/tests/IntegratoR.OData.Tests/ObsoleteApiTests.cs
+++ b/tests/IntegratoR.OData.Tests/ObsoleteApiTests.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+using FluentAssertions;
+using IntegratoR.OData.Common.Exceptions;
+using IntegratoR.OData.Common.Services;
+using IntegratoR.OData.Interfaces.Services;
+using Xunit;
+
+namespace IntegratoR.OData.Tests;
+
+/// <summary>
+/// Reflection pins that assert the deprecation markers on public OData API remain in place.
+/// These guard against premature removal of an <see cref="ObsoleteAttribute"/> before the next MAJOR.
+/// </summary>
+public sealed class ObsoleteApiTests
+{
+    /// <summary>
+    /// <see cref="ODataBatchException"/> is never thrown (batch failures surface via <c>Result&lt;T&gt;</c>)
+    /// and must stay <c>[Obsolete]</c> until removed next MAJOR.
+    /// </summary>
+    [Fact]
+    public void ODataBatchException_IsMarkedObsolete()
+    {
+#pragma warning disable CS0618 // Type or member is obsolete — pinning the deprecation marker
+        ObsoleteAttribute? obsolete = typeof(ODataBatchException).GetCustomAttribute<ObsoleteAttribute>();
+#pragma warning restore CS0618
+
+        obsolete.Should().NotBeNull();
+        obsolete!.Message.Should().Contain("Result");
+    }
+
+    /// <summary>
+    /// The dead, never-injected <see cref="ODataMetadataProvider"/> must stay <c>[Obsolete]</c>
+    /// until removed next MAJOR.
+    /// </summary>
+    [Fact]
+    public void ODataMetadataProvider_IsMarkedObsolete()
+    {
+#pragma warning disable CS0618 // Type or member is obsolete — pinning the deprecation marker
+        ObsoleteAttribute? obsolete = typeof(ODataMetadataProvider).GetCustomAttribute<ObsoleteAttribute>();
+#pragma warning restore CS0618
+
+        obsolete.Should().NotBeNull();
+        obsolete!.Message.Should().Contain("D365 $metadata");
+    }
+
+    /// <summary>
+    /// <see cref="IODataService{TEntity}.FindAll"/> must stay <c>[Obsolete]</c> (callers should use
+    /// <c>FindAllAsync</c>) until removed next MAJOR.
+    /// </summary>
+    [Fact]
+    public void FindAll_IsMarkedObsolete()
+    {
+        MethodInfo? method = typeof(IODataService<>).GetMethod("FindAll");
+
+        method.Should().NotBeNull();
+        ObsoleteAttribute? obsolete = method!.GetCustomAttribute<ObsoleteAttribute>();
+        obsolete.Should().NotBeNull();
+        obsolete!.Message.Should().Contain("FindAllAsync");
+    }
+}

--- a/tests/IntegratoR.TestKit/Doubles/Entities/TestEntity.cs
+++ b/tests/IntegratoR.TestKit/Doubles/Entities/TestEntity.cs
@@ -7,7 +7,7 @@ namespace IntegratoR.TestKit.Doubles.Entities;
 /// A composite-key test entity that mirrors the D365 F&O pattern of combining two string fields
 /// as the primary key. Use in generic handler tests instead of production entities.
 /// </summary>
-public class TestEntity : BaseEntity<string>
+public class TestEntity : BaseEntity
 {
     /// <summary>
     /// Gets or sets the primary identifier. First component of the composite key.

--- a/tests/IntegratoR.TestKit/Doubles/Entities/TestEntityWithD365Attributes.cs
+++ b/tests/IntegratoR.TestKit/Doubles/Entities/TestEntityWithD365Attributes.cs
@@ -10,7 +10,7 @@ namespace IntegratoR.TestKit.Doubles.Entities;
 /// <see cref="ODataFieldAttribute.IsRequired"/>) to verify that <c>ODataService</c> enforces
 /// the extended attribute semantics at runtime.
 /// </summary>
-public class TestEntityWithD365Attributes : BaseEntity<string>
+public class TestEntityWithD365Attributes : BaseEntity
 {
     /// <summary>
     /// Gets or sets the data area (company). Required, editable on create but not after.

--- a/tests/IntegratoR.TestKit/Doubles/Entities/TestEntityWithODataAttributes.cs
+++ b/tests/IntegratoR.TestKit/Doubles/Entities/TestEntityWithODataAttributes.cs
@@ -7,7 +7,7 @@ namespace IntegratoR.TestKit.Doubles.Entities;
 /// A test entity decorated with <see cref="ODataFieldAttribute"/> to verify that OData payload
 /// builders correctly exclude server-generated and read-only fields during create and update operations.
 /// </summary>
-public class TestEntityWithODataAttributes : BaseEntity<string>
+public class TestEntityWithODataAttributes : BaseEntity
 {
     /// <summary>
     /// Gets or sets the primary identifier. Ignored on create because it is server-generated.

--- a/tests/IntegratoR.TestKit/Doubles/Entities/TestSingleKeyEntity.cs
+++ b/tests/IntegratoR.TestKit/Doubles/Entities/TestSingleKeyEntity.cs
@@ -5,7 +5,7 @@ namespace IntegratoR.TestKit.Doubles.Entities;
 /// <summary>
 /// A single integer-key test entity for use in generic handler tests that require a simple key.
 /// </summary>
-public class TestSingleKeyEntity : BaseEntity<int>
+public class TestSingleKeyEntity : BaseEntity
 {
     /// <summary>
     /// Gets or sets the primary integer identifier.

--- a/tests/IntegratoR.TestKit/Fakes/TestCacheableQuery.cs
+++ b/tests/IntegratoR.TestKit/Fakes/TestCacheableQuery.cs
@@ -28,16 +28,20 @@ public sealed class TestCacheableQuery<TResponse> : ICacheableQuery<TResponse>
     }
 
     /// <inheritdoc/>
-    public string CacheKey => GenerateCacheKey();
+    public string CacheKey => _cacheKey;
 
     /// <inheritdoc/>
     public TimeSpan? CacheDuration => _cacheDuration;
 
+    // GetCacheKeyValues/GenerateCacheKey are [Obsolete] on ICacheableQuery but must still be
+    // implemented until the next MAJOR removes the interface members.
+#pragma warning disable CS0618 // Type or member is obsolete
     /// <inheritdoc/>
     public object[] GetCacheKeyValues() => _cacheKeyValues;
 
     /// <inheritdoc/>
     public string GenerateCacheKey() => _cacheKey;
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <inheritdoc/>
     public IReadOnlyDictionary<string, object> GetLoggingContext()

--- a/wiki/Known-Limitations.md
+++ b/wiki/Known-Limitations.md
@@ -4,20 +4,15 @@ This page lists known constraints in the framework and the planned resolutions. 
 
 > Last refreshed against v1.3.5.
 
-## Composite-Key Write Path
+## Composite-Key Write Path — RESOLVED
 
-**What:** `UpdateCommand<T>` and `DeleteCommand<T>` against entities with composite keys (every D365 F&O entity that includes `DataAreaId`) currently route through `PanoramicData.OData.Client`'s single-primitive-key `UpdateAsync` / `DeleteAsync` methods. The composite-key dictionary falls through to `Object.ToString()` and produces a malformed OData URL like `LedgerJournalHeaders(System.Collections.Generic.Dictionary`2[System.String,System.Object])`.
+**Status:** resolved. `UpdateCommand<T>` and `DeleteCommand<T>` against entities with composite keys (every D365 F&O entity that includes `DataAreaId`) now write correctly.
 
-**Symptoms:**
+**What was wrong:** writes previously routed through `PanoramicData.OData.Client`'s single-primitive-key `UpdateAsync` / `DeleteAsync` methods. The composite-key dictionary fell through to `Object.ToString()` and produced a malformed OData URL like `LedgerJournalHeaders(System.Collections.Generic.Dictionary`2[System.String,System.Object])`, so updates returned `*.NotFound` and deletes silently no-opped.
 
-- `UpdateCommand<LedgerJournalHeader>` returns `Result.Fail(IntegrationError("LedgerJournalHeader.NotFound", "Resource not found: LedgerJournalHeaders(System.Collections.Generic.Dictionary…)", NotFound))`.
-- `DeleteCommand<LedgerJournalHeader>` returns `Result.Ok` with a `Warning` log line that says *"may indicate a malformed request URL"* — this is the framework's observability fix (since v1.3.4) surfacing the silent failure that would otherwise look like a successful delete.
+**How it is fixed:** `ODataClientAdapter` detects a composite key (an `IDictionary<string, object>`) and issues the PATCH / DELETE through an owned raw-`HttpClient` bypass that builds the keyed URL manually — `LedgerJournalHeaders(dataAreaId='USMF',JournalBatchNumber='B0001')` — sent through the named `"ODataClient"` client so it carries the same authentication, Polly resilience, and `BaseAddress` as every other request. This mirrors the long-standing read-path bypass used by `GetByKeyQuery<T>`. The bypass is owned, first-party source maintained in this repository (not a fork awaiting upstream).
 
-**Why:** PanoramicData.OData.Client 10.0.55 has no API overload that accepts a composite key for write operations. The library's internal `ODataEntityType.Key` tracks the multiple key fields per entity, but `UpdateAsync` and `DeleteAsync` expose only `Key(object)` / `Key<TKey>(TKey)`. The library would need an upstream PR adding `Key(IDictionary<string, object>)` overloads.
-
-**Workaround status:** Read paths (`GetByKeyQuery<T>`) already work — they bypass the limitation by constructing a `$filter` predicate. The write-path workaround is a planned raw `HttpClient` bypass in `ODataClientAdapter` that builds the composite-key URL manually for `UpdateAsync` / `DeleteAsync`. The design is fully scoped and tracked internally by maintainers. Implementation is queued behind smoke-test and dimension-related work that ships first.
-
-**Mitigation today:** treat write-path failures as recoverable in the consumer's code. The framework's `Warning` log for suppressed-404 delete is the diagnostic signal. For one-off cleanup of orphan rows created by the LedgerJournal smoke test, use the D365 UI.
+**Coverage:** adapter-level unit tests pin the keyed URL construction, value formatting (string / Guid / enum / `DateOnly`), and the 404-treated-as-success delete path; the LedgerJournal smoke test exercises the create → update → re-read → delete → verify-gone round-trip end to end.
 
 ## `IValidateOptions<T>` Not Implemented
 


### PR DESCRIPTION
Fourth of the fix series. API hygiene, dead-code deprecation, and the ownership reframing of the PanoramicData extension.

## Changes
- **Deprecations** (`[Obsolete("since v1.4.0; …")]`, removed next MAJOR): `BaseEntity<TKey>`, `ICacheableQuery.GenerateCacheKey`/`GetCacheKeyValues`, `ODataBatchException`, `IODataService.FindAll`, `ODataMetadataProvider` (+ dropped its dead DI registration).
- **New non-generic `BaseEntity`** (`BaseEntity<TKey> : BaseEntity`) with a static reflection cache in `GetLoggingContext`; all entities/CodeGen/TestKit doubles migrated.
- **`FindAllAsync`** added; `FindAll` deprecated + delegates.
- **Entities**: removed inert `[Required]` DataAnnotations; consumer-supplied create fields now `[ODataField(IsRequired = true)]` (enforced by the payload builder).
- **Docs**: `IService<T>` no longer described as a Repository; `THIRD_PARTY_LICENSES` + translator header reframed as a **permanent owned extension** (MIT attribution retained); `Known-Limitations` composite-key-write marked resolved; `architecture.md` records the accepted `IEntity.GetLoggingContext()` trade-off.
- DI: the multiple stateless `ODataService<>` registrations are documented as intentionally tolerated (no forwarder — LOW severity, zero observable impact).

## Discovery (tracked follow-up)
The open-generic command validators never fire through the MediatR pipeline (FluentValidation can't register open generics) — recorded as a high-priority backlog item; out of scope here.

## Verification
- `dotnet build` 0 errors, 0 warnings; `dotnet test` **556 passed, 0 failed, 0 skipped** (+10 incl. obsolete-attribute pins + non-generic `BaseEntity` round-trip).
- `code-reviewer`: approve-with-changes → the one Major (`LedgerJournalHeader.DataAreaId` missing `[ODataField(IsRequired)]`) fixed.

## Semver
`+semver: minor` — all additive (`BaseEntity`, `FindAllAsync`) or `[Obsolete]`; nothing removed this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)