### PR TITLE
chore: post-review remediation + signal v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ Versions are computed automatically by [GitVersion](https://gitversion.net/) in 
 
 ## [Unreleased]
 
+> **Next release: 2.0.0 (MAJOR).** The architecture-review fix series (PRs #131–135) shipped breaking public-API changes (see **Changed — Breaking**) that were mis-tagged `+semver: minor`; `GitVersion.yml` pins `next-version: 2.0.0` to correct the signal.
+
 ### Added
+- Composite-key **write** support (Update / Delete / batch) for D365 F&O entities via a raw-`HttpClient` bypass in `ODataClientAdapter`, closing the long-standing PanoramicData composite-key write limitation.
+- Strongly-typed `$orderby` on queries (`IODataService` / `IODataClientAdapter` typed overloads; `[JsonPropertyName]`-aware translation).
+- `ODataSettingsValidator` (`IValidateOptions<ODataSettings>` + `ValidateOnStart`): fails fast on an auth header smuggled into `DefaultHeaders`, on per-mode credential gaps, and on an unrecognised `AuthenticationMode`.
+- `IBatchService<TEntity>` (in `IntegratoR.Abstractions`) with generic `Create`/`Update`/`DeleteBatchCommandHandler<T>`.
+- `ResultFactory` — cached-reflection failed-result factory shared by `ValidationBehaviour` and `ODataExceptionHandler`.
+- Non-generic `BaseEntity` base class.
 - Open source best practices: community health files, CI/CD, build infrastructure
 - Central package version management via `Directory.Packages.props`
 - Shared build properties via `Directory.Build.props`
@@ -17,6 +25,22 @@ Versions are computed automatically by [GitVersion](https://gitversion.net/) in 
 - Issue and PR templates
 - Dependabot configuration for automated dependency updates
 - Branch protection rules on `main`
+
+### Changed — Breaking
+- `IODataClientAdapter.FindEntriesAsync` gained an `orderBy` parameter (ordered `(keySelector, descending)` tuples) inserted before `skip`/`top`. Implementors and named-argument callers must update.
+- `CreateBatchCommand<T>` / `UpdateBatchCommand<T>` / `DeleteBatchCommand<T>` (and the F&O command records deriving from them) now take `IReadOnlyList<T>` instead of `IEnumerable<T>`, removing multiple-enumeration and giving O(1) `Count`.
+- `GetDimensionOrdersQuery` positional parameters renamed `dimensionFormat`/`hierarchyType` → `DimensionFormat`/`HierarchyType` (C# PascalCase convention).
+
+### Deprecated
+- `BaseEntity<TKey>` (the `TKey` parameter was never used — derive from the non-generic `BaseEntity`), `IODataService.FindAll` (use `FindAllAsync`), `ODataBatchException`, `ICacheableQuery.GenerateCacheKey` / `GetCacheKeyValues`, and `ODataMetadataProvider`. All marked `[Obsolete]`; removed in the next MAJOR.
+
+### Security
+- 401/403 responses and OAuth token-acquisition failures no longer leak MSAL / tenant detail in HTTP `ReasonPhrase` or error messages (full detail is logged server-side only).
+- `LoggingBehaviour` moved request-body destructuring from Information to Debug to avoid logging payloads at the default level.
+
+### Fixed
+- `LoggingBehaviour` logged a failed `Result<T>` as a success (only the non-generic `Result` was inspected).
+- Smoke-test Update/Delete verify steps no longer misfire when the preceding write fails.
 
 ### Removed
 - `IntegratoR.RELion` integration module (RELion property-management REST API client, auth handler, domain entities, and ledger query). Out of scope for the framework's Microsoft-business-application OData focus; the module was never published to NuGet.

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -6,7 +6,11 @@ assembly-file-versioning-scheme: MajorMinorPatch
 
 workflow: GitHubFlow/v1
 mode: ContinuousDelivery
-next-version: 1.1.0
+# Bumped to 2.0.0: the architecture-review fix series (PRs #131-135) shipped breaking
+# public-API changes (FindEntriesAsync orderBy param; batch commands IEnumerable->IReadOnlyList;
+# GetDimensionOrdersQuery param rename) that were mis-tagged +semver:minor. This pins the next
+# stable release to a MAJOR. See CHANGELOG.md "Changed - Breaking".
+next-version: 2.0.0
 
 branches:
   main:

--- a/IntegratoR.OData/Common/Services/ODataClientAdapter.cs
+++ b/IntegratoR.OData/Common/Services/ODataClientAdapter.cs
@@ -1,6 +1,5 @@
 using System.Linq.Expressions;
 using System.Net;
-using System.Net.Http.Headers;
 using System.Text;
 using IntegratoR.Abstractions.Interfaces.Entity;
 using IntegratoR.OData.Common.Filters;

--- a/IntegratoR.OData/Domain/Settings/ODataSettingsValidator.cs
+++ b/IntegratoR.OData/Domain/Settings/ODataSettingsValidator.cs
@@ -85,6 +85,15 @@ public sealed class ODataSettingsValidator : IValidateOptions<ODataSettings>
                 }
 
                 break;
+
+            default:
+                // An out-of-range enum value (e.g. from a typo'd config binding) must not pass
+                // silently — the auth handler would otherwise fall through to the ApiKey/APIM path
+                // with no credentials. Fail fast and force an explicit, recognised mode.
+                failures.Add(
+                    $"ODataSettings.Authentication.Mode has an unrecognised value '{options.Authentication.Mode}'. " +
+                    "Set it explicitly to ApiKey or OAuth.");
+                break;
         }
 
         return failures.Count > 0

--- a/tests/IntegratoR.Abstractions.Tests/Common/Results/ResultFactoryTests.cs
+++ b/tests/IntegratoR.Abstractions.Tests/Common/Results/ResultFactoryTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using FluentResults;
 using IntegratoR.Abstractions.Common.Results;
@@ -43,5 +45,32 @@ public class ResultFactoryTests
         result.Should().BeOfType<Result>();
         result.IsFailed.Should().BeTrue();
         result.GetError()!.Code.Should().Be("Some.Code");
+    }
+
+    [Fact]
+    public void FailFromError_UnsupportedResultType_ThrowsNotSupportedException()
+    {
+        // Arrange
+        var error = new IntegrationError("Some.Code", "some message", ErrorType.Failure);
+
+        // Act
+        Action act = () => ResultFactory.FailFromError<CustomResult>(error);
+
+        // Assert -- a custom IResultBase that is neither Result nor Result<T> is a programming
+        // error, not a business failure, so the factory throws rather than returning a result.
+        act.Should().Throw<NotSupportedException>();
+    }
+
+    /// <summary>
+    /// A custom <see cref="IResultBase"/> that is neither <see cref="Result"/> nor
+    /// <see cref="Result{TValue}"/>, used to exercise the unsupported-type guard.
+    /// </summary>
+    private sealed class CustomResult : IResultBase
+    {
+        public bool IsFailed => true;
+        public bool IsSuccess => false;
+        public List<IReason> Reasons => [];
+        public IReadOnlyList<IError> Errors => [];
+        public IReadOnlyList<ISuccess> Successes => [];
     }
 }

--- a/tests/IntegratoR.Hosting.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/tests/IntegratoR.Hosting.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -476,6 +476,75 @@ public class ServiceCollectionExtensionsTests
         }
     }
 
+    [Fact]
+    public async Task AddIntegratoR_GenericCreateBatchCommandHandler_PropagatesServiceFailure()
+    {
+        // Arrange
+        (ServiceProvider provider, IBatchService<LedgerJournalHeader> service) = BuildProviderWithSubstitutedBatchService();
+        await using (provider)
+        {
+            service.AddBatchAsync(Arg.Any<IEnumerable<LedgerJournalHeader>>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(Result.Fail(new IntegrationError("Batch.Create.Failed", "create batch failed", ErrorType.Failure))));
+
+            using IServiceScope scope = provider.CreateScope();
+            IMediator mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            // Act
+            Result result =
+                await mediator.Send(new CreateBatchCommand<LedgerJournalHeader>(new[] { CreateTestHeader() }), TestContext.Current.CancellationToken);
+
+            // Assert -- the handler propagates the service failure unchanged; it does not throw.
+            result.Should().BeFailed();
+            result.Should().HaveErrorCode("Batch.Create.Failed");
+        }
+    }
+
+    [Fact]
+    public async Task AddIntegratoR_GenericUpdateBatchCommandHandler_PropagatesServiceFailure()
+    {
+        // Arrange
+        (ServiceProvider provider, IBatchService<LedgerJournalHeader> service) = BuildProviderWithSubstitutedBatchService();
+        await using (provider)
+        {
+            service.UpdateBatchAsync(Arg.Any<IEnumerable<LedgerJournalHeader>>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(Result.Fail(new IntegrationError("Batch.Update.Failed", "update batch failed", ErrorType.Failure))));
+
+            using IServiceScope scope = provider.CreateScope();
+            IMediator mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            // Act
+            Result result =
+                await mediator.Send(new UpdateBatchCommand<LedgerJournalHeader>(new[] { CreateTestHeader() }), TestContext.Current.CancellationToken);
+
+            // Assert
+            result.Should().BeFailed();
+            result.Should().HaveErrorCode("Batch.Update.Failed");
+        }
+    }
+
+    [Fact]
+    public async Task AddIntegratoR_GenericDeleteBatchCommandHandler_PropagatesServiceFailure()
+    {
+        // Arrange
+        (ServiceProvider provider, IBatchService<LedgerJournalHeader> service) = BuildProviderWithSubstitutedBatchService();
+        await using (provider)
+        {
+            service.DeleteBatchAsync(Arg.Any<IEnumerable<LedgerJournalHeader>>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(Result.Fail(new IntegrationError("Batch.Delete.Failed", "delete batch failed", ErrorType.Failure))));
+
+            using IServiceScope scope = provider.CreateScope();
+            IMediator mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            // Act
+            Result result =
+                await mediator.Send(new DeleteBatchCommand<LedgerJournalHeader>(new[] { CreateTestHeader() }), TestContext.Current.CancellationToken);
+
+            // Assert
+            result.Should().BeFailed();
+            result.Should().HaveErrorCode("Batch.Delete.Failed");
+        }
+    }
+
     // Pinned behaviour for PR-C: AddIntegratoR now registers the F&O FluentValidation validators
     // (step 6). GetDimensionOrdersQueryValidator — a non-generic validator — therefore fires in the
     // MediatR ValidationBehaviour: an invalid (empty DimensionFormat) query is short-circuited with

--- a/tests/IntegratoR.OData.FO.Tests/Domain/Entities/LedgerJournal/LedgerJournalLineTests.cs
+++ b/tests/IntegratoR.OData.FO.Tests/Domain/Entities/LedgerJournal/LedgerJournalLineTests.cs
@@ -85,4 +85,24 @@ public class LedgerJournalLineTests
             attribute.IgnoreOnCreate.Should().BeFalse("CurrencyCode is consumer-supplied and must reach the wire");
         }
     }
+
+    /// <summary>
+    /// Regression pin: DebitAmount and CreditAmount are consumer-supplied and must reach the wire
+    /// even at their <c>0m</c> default (a balanced line always has one side at zero). They carry
+    /// <c>[ODataField(IsRequired = true)]</c> so <c>CreatePayload</c> forces them into the create
+    /// payload rather than dropping them as default-valued.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(LedgerJournalLine.DebitAmount))]
+    [InlineData(nameof(LedgerJournalLine.CreditAmount))]
+    public void Amount_CarriesIsRequired(string propertyName)
+    {
+        PropertyInfo? property = typeof(LedgerJournalLine).GetProperty(propertyName);
+
+        property.Should().NotBeNull();
+        ODataFieldAttribute? attribute = property!.GetCustomAttribute<ODataFieldAttribute>();
+
+        attribute.Should().NotBeNull("the amount must be forced into the create payload at its 0m default");
+        attribute!.IsRequired.Should().BeTrue();
+    }
 }

--- a/tests/IntegratoR.OData.Tests/Domain/Settings/ODataSettingsValidatorTests.cs
+++ b/tests/IntegratoR.OData.Tests/Domain/Settings/ODataSettingsValidatorTests.cs
@@ -183,4 +183,33 @@ public class ODataSettingsValidatorTests
         // Assert
         result.Succeeded.Should().BeTrue();
     }
+
+    /// <summary>
+    /// An out-of-range <see cref="AuthenticationMode"/> (e.g. a typo'd config binding) must fail
+    /// fast rather than fall through to the credential-less APIM path.
+    /// </summary>
+    [Fact]
+    public void Validate_UnrecognisedAuthenticationMode_Fails()
+    {
+        // Arrange
+        var settings = new ODataSettings
+        {
+            Url = "https://test.operations.dynamics.com/data",
+            Authentication = new ODataAuthenticationSettings
+            {
+                Mode = (AuthenticationMode)999,
+                ApiManagement = new ODataApiManagementSettings
+                {
+                    SubscriptionKey = "valid-key",
+                    SubscriptionHeaderKey = "Ocp-Apim-Subscription-Key"
+                }
+            }
+        };
+
+        // Act
+        var result = _sut.Validate(null, settings);
+
+        // Assert
+        result.Failed.Should().BeTrue();
+    }
 }

--- a/wiki/Work-with-Dimensions.md
+++ b/wiki/Work-with-Dimensions.md
@@ -14,8 +14,8 @@ using IntegratoR.OData.FO.Features.Queries.Dimensions.GetDimensionOrder;
 
 Result<DimensionFormat> result = await mediator.Send(
     new GetDimensionOrdersQuery(
-        dimensionFormat: "Sachkontodimensionen",
-        hierarchyType: DimensionHierarchyType.DataEntityLedgerDimensionFormat),
+        DimensionFormat: "Sachkontodimensionen",
+        HierarchyType: DimensionHierarchyType.DataEntityLedgerDimensionFormat),
     cancellationToken).ConfigureAwait(false);
 
 if (result.IsSuccess)
@@ -26,7 +26,7 @@ if (result.IsSuccess)
 }
 ```
 
-The query signature is `GetDimensionOrdersQuery(string dimensionFormat, DimensionHierarchyType hierarchyType)`. Both parameters are part of the entity's composite filter: `dimensionFormat` matches `DimensionIntegrationFormat.DimensionFormatName`, `hierarchyType` matches `DimensionIntegrationFormat.DimensionFormatType`.
+The query signature is `GetDimensionOrdersQuery(string DimensionFormat, DimensionHierarchyType HierarchyType)`. Both parameters are part of the entity's composite filter: `DimensionFormat` matches `DimensionIntegrationFormat.DimensionFormatName`, `HierarchyType` matches `DimensionIntegrationFormat.DimensionFormatType`.
 
 The handler chains two calls to D365:
 


### PR DESCRIPTION
## Summary

Remediation from the **independent post-merge review of PRs #131–135** (the architecture-review fix series), plus the version-signal correction.

### Release signal (the headline)
The fix series shipped three **breaking** changes to shipped public API (verified against the `v1.3.6` tag) under `+semver: minor`:
- `IODataClientAdapter.FindEntriesAsync` — `orderBy` parameter inserted before `skip`/`top`.
- `CreateBatchCommand<T>` / `UpdateBatchCommand<T>` / `DeleteBatchCommand<T>` — `IEnumerable<T>` → `IReadOnlyList<T>`.
- `GetDimensionOrdersQuery` — positional params renamed to PascalCase.

Per the owner's decision, we **keep** these improvements and signal honestly: `GitVersion.yml` `next-version: 2.0.0`, with the breaks + full release contents documented in `CHANGELOG.md`.

### Fixes & coverage
- **`ODataSettingsValidator`** — added the missing `default` case: an unrecognised `AuthenticationMode` now fails fast instead of falling through to the credential-less APIM path. + regression test.
- **`ResultFactory`** — pinned the `NotSupportedException` (unsupported result type) path.
- **Generic batch handlers** — added failure-path tests proving the handlers propagate a service `Result.Fail` without throwing.
- **`LedgerJournalLine`** — pinned `Debit/CreditAmount` `[ODataField(IsRequired = true)]`.
- Removed an unused `using` in `ODataClientAdapter`; fixed stale camelCase `GetDimensionOrdersQuery` args in `wiki/Work-with-Dimensions.md`.

Three pre-existing findings (D365 inner-error leak into `IntegrationError.Message`; non-401/403 `exception.Message` interpolation; Polly retry on non-idempotent PATCH/DELETE) were **deferred** to the backlog — they predate this series and the leak fix is its own API-design change.

## Risks / rollback
The only behavioural change is the validator now rejecting an out-of-range mode (previously silently accepted). Everything else is tests, docs, and the version/CHANGELOG signal. Revert = revert the three commits.

## Reviewer focus
- The v2.0.0 `next-version` pin is the intended MAJOR signal; confirm the CHANGELOG breaking-change list is complete and accurate.
- `ODataSettingsValidator` default case wording + the `(AuthenticationMode)999` test.

## Verification
`dotnet build` clean (0 warnings, 0 errors); `dotnet test` → **563 passed, 0 failed** (was 556; +7 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)