### PR TITLE
fix: activate generic command validation + live-verified composite-key write hardening + CRUD integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ Versions are computed automatically by [GitVersion](https://gitversion.net/) in 
 
 ## [Unreleased]
 
-> **Next release: 2.0.0 (MAJOR).** The architecture-review fix series (PRs #131–135) shipped breaking public-API changes (see **Changed — Breaking**) that were mis-tagged `+semver: minor`; `GitVersion.yml` pins `next-version: 2.0.0` to correct the signal.
+### Added
+- Generic command validation now runs through the MediatR pipeline. `AddIntegratoR` closes the open-generic command/query validators (`CreateCommand<T>`, the batch variants, `GetByKeyQuery`/`GetByFilterQuery`, and the F&O-derived per-command validators) over the discovered entity types and registers them, so validation that was previously never resolved now fires. **Behavioural change:** a `CreateCommand<T>(null)`, a null/empty batch, or an empty composite key now short-circuits with a Validation failure for every consumer instead of reaching the handler.
+
+### Fixed
+- `ODataService.UpdateAsync` returned a successful `Result` with a null `Value` when a composite-key PATCH came back as `204 No Content`; it now returns the written entity.
+- `LedgerJournalHeader` read-only fields (`JournalName`, `AccountingCurrency`, `IsPosted`, `JournalTotalDebit`, `JournalTotalCredit`) are now `[ODataField(IgnoreOnUpdate = true)]`, so D365 no longer rejects the whole update PATCH with an `ODataSecurityException`.
+- The six generic commands' `GetLoggingContext()` are null-safe, so `LoggingBehaviour` (which runs before `ValidationBehaviour`) no longer NREs on a null command payload before validation can reject it.
+
+## [2.0.0] - 2026-06-30
+
+The architecture-review fix series (PRs #131–135) plus post-review remediation, released as a MAJOR (breaking public-API changes — see **Changed — Breaking**).
 
 ### Added
 - Composite-key **write** support (Update / Delete / batch) for D365 F&O entities via a raw-`HttpClient` bypass in `ODataClientAdapter`, closing the long-standing PanoramicData composite-key write limitation.

--- a/IntegratoR.Abstractions/Common/CQRS/Commands/CreateBatchCommand.cs
+++ b/IntegratoR.Abstractions/Common/CQRS/Commands/CreateBatchCommand.cs
@@ -20,9 +20,11 @@ namespace IntegratoR.Abstractions.Common.CQRS.Commands
         /// </summary>
         public virtual IReadOnlyDictionary<string, object> GetLoggingContext()
         {
+            // Null-safe: a null Entities collection is an invalid command that ValidationBehaviour
+            // will reject; LoggingBehaviour runs first, so this must not throw.
             return new Dictionary<string, object>
             {
-                { "Count", Entities.Count }
+                { "Count", Entities?.Count ?? 0 }
             };
         }
     }

--- a/IntegratoR.Abstractions/Common/CQRS/Commands/CreateCommand.cs
+++ b/IntegratoR.Abstractions/Common/CQRS/Commands/CreateCommand.cs
@@ -17,7 +17,11 @@ namespace IntegratoR.Abstractions.Common.CQRS.Commands
         /// </summary>
         public virtual IReadOnlyDictionary<string, object> GetLoggingContext()
         {
-            return Entity.GetLoggingContext();
+            // Null-safe: the record permits a null Entity (an invalid command that ValidationBehaviour
+            // will reject). LoggingBehaviour runs before validation, so building the logging context
+            // must not throw. Mirrors GetByKeyQuery.GetLoggingContext's null handling.
+            return Entity?.GetLoggingContext()
+                ?? new Dictionary<string, object> { { "EntityType", typeof(TEntity).Name } };
         }
     }
 }

--- a/IntegratoR.Abstractions/Common/CQRS/Commands/DeleteBatchCommand.cs
+++ b/IntegratoR.Abstractions/Common/CQRS/Commands/DeleteBatchCommand.cs
@@ -20,9 +20,11 @@ namespace IntegratoR.Abstractions.Common.CQRS.Commands
         /// </summary>
         public virtual IReadOnlyDictionary<string, object> GetLoggingContext()
         {
+            // Null-safe: a null Entities collection is an invalid command that ValidationBehaviour
+            // will reject; LoggingBehaviour runs first, so this must not throw.
             return new Dictionary<string, object>
             {
-                { "Count", Entities.Count }
+                { "Count", Entities?.Count ?? 0 }
             };
         }
     }

--- a/IntegratoR.Abstractions/Common/CQRS/Commands/DeleteCommand.cs
+++ b/IntegratoR.Abstractions/Common/CQRS/Commands/DeleteCommand.cs
@@ -20,7 +20,11 @@ namespace IntegratoR.Abstractions.Common.CQRS.Commands
         /// </summary>
         public virtual IReadOnlyDictionary<string, object> GetLoggingContext()
         {
-            return Entity.GetLoggingContext();
+            // Null-safe: the record permits a null Entity (an invalid command that ValidationBehaviour
+            // will reject). LoggingBehaviour runs before validation, so building the logging context
+            // must not throw. Mirrors GetByKeyQuery.GetLoggingContext's null handling.
+            return Entity?.GetLoggingContext()
+                ?? new Dictionary<string, object> { { "EntityType", typeof(TEntity).Name } };
         }
     }
 }

--- a/IntegratoR.Abstractions/Common/CQRS/Commands/UpdateBatchCommand.cs
+++ b/IntegratoR.Abstractions/Common/CQRS/Commands/UpdateBatchCommand.cs
@@ -20,9 +20,11 @@ namespace IntegratoR.Abstractions.Common.CQRS.Commands
         /// </summary>
         public virtual IReadOnlyDictionary<string, object> GetLoggingContext()
         {
+            // Null-safe: a null Entities collection is an invalid command that ValidationBehaviour
+            // will reject; LoggingBehaviour runs first, so this must not throw.
             return new Dictionary<string, object>
             {
-                { "Count", Entities.Count }
+                { "Count", Entities?.Count ?? 0 }
             };
         }
     }

--- a/IntegratoR.Abstractions/Common/CQRS/Commands/UpdateCommand.cs
+++ b/IntegratoR.Abstractions/Common/CQRS/Commands/UpdateCommand.cs
@@ -20,7 +20,11 @@ namespace IntegratoR.Abstractions.Common.CQRS.Commands
         /// </summary>
         public virtual IReadOnlyDictionary<string, object> GetLoggingContext()
         {
-            return Entity.GetLoggingContext();
+            // Null-safe: the record permits a null Entity (an invalid command that ValidationBehaviour
+            // will reject). LoggingBehaviour runs before validation, so building the logging context
+            // must not throw. Mirrors GetByKeyQuery.GetLoggingContext's null handling.
+            return Entity?.GetLoggingContext()
+                ?? new Dictionary<string, object> { { "EntityType", typeof(TEntity).Name } };
         }
     }
 }

--- a/IntegratoR.Hosting/Extensions/ServiceCollectionExtensions.cs
+++ b/IntegratoR.Hosting/Extensions/ServiceCollectionExtensions.cs
@@ -166,7 +166,7 @@ public static class IntegratoRServiceCollectionExtensions
         Assembly[] entityAssemblies)
     {
         List<Type> openValidators = validatorAssemblies
-            .SelectMany(assembly => assembly.GetTypes())
+            .SelectMany(GetLoadableTypes)
             .Where(type => type is { IsAbstract: false, IsGenericTypeDefinition: true }
                            && type.GetGenericArguments().Length == 1
                            && GetValidatedRequestType(type) is not null)
@@ -174,7 +174,7 @@ public static class IntegratoRServiceCollectionExtensions
             .ToList();
 
         List<Type> entityTypes = entityAssemblies
-            .SelectMany(assembly => assembly.GetTypes())
+            .SelectMany(GetLoadableTypes)
             .Where(type => type is { IsAbstract: false, IsGenericTypeDefinition: false }
                            && typeof(IEntity).IsAssignableFrom(type))
             .Distinct()
@@ -199,6 +199,20 @@ public static class IntegratoRServiceCollectionExtensions
                 // AddIntegratoR is called twice and never double-registers the same validator.
                 services.TryAddEnumerable(ServiceDescriptor.Transient(serviceType, implementationType));
             }
+        }
+    }
+
+    // A consumer assembly may reference a type it cannot load; Assembly.GetTypes() would then throw
+    // ReflectionTypeLoadException and crash AddIntegratoR. Fall back to the types that DID load.
+    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(type => type is not null)!;
         }
     }
 

--- a/IntegratoR.Hosting/Extensions/ServiceCollectionExtensions.cs
+++ b/IntegratoR.Hosting/Extensions/ServiceCollectionExtensions.cs
@@ -128,7 +128,9 @@ public static class IntegratoRServiceCollectionExtensions
         //     would silently never run. Entities come from the F&O assembly AND consumer assemblies (a
         //     consumer's CreateCommand<ConsumerEntity> needs its validator too); the open-generic
         //     validators come from IntegratoR.Application (baseline) and IntegratoR.OData.FO (derived).
-        //     See open-todos #15.
+        //     (The F&O-derived per-command validators are also closed and registered here as a benign
+        //     side-effect — nothing dispatches those FO-specific commands through the mediator today,
+        //     and TryAddEnumerable keeps the registration harmless.) See open-todos #15.
         RegisterClosedGenericValidators(
             services,
             validatorAssemblies:

--- a/IntegratoR.Hosting/Extensions/ServiceCollectionExtensions.cs
+++ b/IntegratoR.Hosting/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
+using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using FluentValidation;
 using IntegratoR.Abstractions.Common.Results.SystemText;
+using IntegratoR.Abstractions.Interfaces.Entity;
 using IntegratoR.Application.Common.Extensions;
 using IntegratoR.Hosting;
 using IntegratoR.OData.Common.Extensions;
@@ -12,6 +14,7 @@ using MediatR;
 using Microsoft.DurableTask.Converters;
 using Microsoft.DurableTask.Worker;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -106,22 +109,38 @@ public static class IntegratoRServiceCollectionExtensions
         // 6. Register the F&O FluentValidation validators. The F&O layer (AddODataClientFOProxy)
         //    registers its MediatR handlers but not its validators; wiring them here keeps the
         //    FluentValidation.DependencyInjectionExtensions dependency in the composition root.
-        //    This registers the NON-GENERIC GetDimensionOrdersQueryValidator, which then fires in
-        //    the MediatR ValidationBehaviour.
+        //    This registers the NON-GENERIC, concrete validators (e.g. GetDimensionOrdersQueryValidator),
+        //    which fire in the MediatR ValidationBehaviour.
         //
-        //    KNOWN LIMITATION: AddValidatorsFromAssembly's assembly scanner does NOT register
-        //    OPEN-GENERIC validators (it cannot build a closed IValidator<> service type from a
-        //    partially-open generic). This affects BOTH the generic baseline validators in
-        //    IntegratoR.Application (CreateCommandValidator<T> etc.) AND the thin derived per-command
-        //    validators in IntegratoR.OData.FO (CreateLedgerJournalLineCommandValidator<T> etc.).
-        //    Consequently, generic/open-generic command validation does NOT run through the pipeline
-        //    today — a pre-existing framework-wide gap, not introduced here. The derived FO
-        //    validators are still useful and are unit-proven against the concrete FO commands in
-        //    GenericValidatorReuseTests; closing the open-generic pipeline gap is deferred (it needs
-        //    a per-entity closed-validator registration mechanism, out of scope for PR-C).
+        //    AddValidatorsFromAssembly's scanner does NOT register OPEN-GENERIC validators (it cannot
+        //    build a closed IValidator<> service type from a partially-open generic). The generic
+        //    baseline validators (CreateCommandValidator<T> etc.) and the F&O-derived per-command
+        //    validators are therefore closed and registered explicitly in step 6b below.
         services.AddValidatorsFromAssembly(
             typeof(IntegratoR.OData.FO.Domain.Entities.LedgerJournal.LedgerJournalHeader).Assembly,
             includeInternalTypes: true);
+
+        // 6b. Close the OPEN-GENERIC command/query validators over every discovered entity type and
+        //     register the resulting CLOSED IValidator<> so they actually fire in ValidationBehaviour.
+        //     Step 6 (and AddApplicationServices) cannot: the FluentValidation scanner skips open
+        //     generics, so mediator.Send(new CreateCommand<TEntity>(...)) would otherwise resolve an
+        //     EMPTY IEnumerable<IValidator<CreateCommand<TEntity>>> and generic command validation
+        //     would silently never run. Entities come from the F&O assembly AND consumer assemblies (a
+        //     consumer's CreateCommand<ConsumerEntity> needs its validator too); the open-generic
+        //     validators come from IntegratoR.Application (baseline) and IntegratoR.OData.FO (derived).
+        //     See open-todos #15.
+        RegisterClosedGenericValidators(
+            services,
+            validatorAssemblies:
+            [
+                typeof(IntegratoR.Application.Features.Common.Validators.CreateCommandValidator<>).Assembly,
+                typeof(IntegratoR.OData.FO.Domain.Entities.LedgerJournal.LedgerJournalHeader).Assembly,
+            ],
+            entityAssemblies:
+            [
+                typeof(IntegratoR.OData.FO.Domain.Entities.LedgerJournal.LedgerJournalHeader).Assembly,
+                .. builder.ConsumerAssemblies,
+            ]);
 
         // 7. Register consumer FluentValidation validators. Consumer MediatR handlers — including
         //    the closed generic CRUD/query handlers for consumer entities — are already registered
@@ -133,5 +152,108 @@ public static class IntegratoRServiceCollectionExtensions
         }
 
         return services;
+    }
+
+    // Open-generic validators (AbstractValidator<TRequest<TArg>>) are skipped by FluentValidation's
+    // assembly scanner because there is no closed IValidator<> service type to bind. This closes each
+    // over every discovered entity that satisfies its generic constraints and registers the resulting
+    // closed IValidator<> so ValidationBehaviour resolves and runs them.
+    private static void RegisterClosedGenericValidators(
+        IServiceCollection services,
+        Assembly[] validatorAssemblies,
+        Assembly[] entityAssemblies)
+    {
+        List<Type> openValidators = validatorAssemblies
+            .SelectMany(assembly => assembly.GetTypes())
+            .Where(type => type is { IsAbstract: false, IsGenericTypeDefinition: true }
+                           && type.GetGenericArguments().Length == 1
+                           && GetValidatedRequestType(type) is not null)
+            .Distinct()
+            .ToList();
+
+        List<Type> entityTypes = entityAssemblies
+            .SelectMany(assembly => assembly.GetTypes())
+            .Where(type => type is { IsAbstract: false, IsGenericTypeDefinition: false }
+                           && typeof(IEntity).IsAssignableFrom(type))
+            .Distinct()
+            .ToList();
+
+        foreach (Type openValidator in openValidators)
+        {
+            Type parameter = openValidator.GetGenericArguments()[0];
+
+            foreach (Type entity in entityTypes)
+            {
+                if (!SatisfiesConstraints(parameter, entity))
+                {
+                    continue;
+                }
+
+                Type implementationType = openValidator.MakeGenericType(entity);
+                Type requestType = GetValidatedRequestType(implementationType)!;    // e.g. CreateCommand<TEntity> (closed)
+                Type serviceType = typeof(IValidator<>).MakeGenericType(requestType);
+
+                // TryAddEnumerable dedupes on (service, implementation) so the pass is idempotent when
+                // AddIntegratoR is called twice and never double-registers the same validator.
+                services.TryAddEnumerable(ServiceDescriptor.Transient(serviceType, implementationType));
+            }
+        }
+    }
+
+    // Returns the TRequest of the nearest AbstractValidator<TRequest> in the inheritance chain, or
+    // null when the type does not derive from AbstractValidator<>.
+    private static Type? GetValidatedRequestType(Type validatorType)
+    {
+        for (Type? current = validatorType.BaseType; current is not null; current = current.BaseType)
+        {
+            if (current.IsGenericType && current.GetGenericTypeDefinition() == typeof(AbstractValidator<>))
+            {
+                return current.GetGenericArguments()[0];
+            }
+        }
+
+        return null;
+    }
+
+    // Whether 'candidate' satisfies every generic constraint declared on 'genericParameter', so
+    // MakeGenericType(candidate) will not throw. Lets one pass cover baseline validators (constraint
+    // IEntity) and F&O-derived validators (constraint LedgerJournalHeader/Line) without exceptions.
+    private static bool SatisfiesConstraints(Type genericParameter, Type candidate)
+    {
+        GenericParameterAttributes attributes =
+            genericParameter.GenericParameterAttributes & GenericParameterAttributes.SpecialConstraintMask;
+
+        if (attributes.HasFlag(GenericParameterAttributes.ReferenceTypeConstraint) && candidate.IsValueType)
+        {
+            return false;
+        }
+
+        if (attributes.HasFlag(GenericParameterAttributes.NotNullableValueTypeConstraint) && !candidate.IsValueType)
+        {
+            return false;
+        }
+
+        if (attributes.HasFlag(GenericParameterAttributes.DefaultConstructorConstraint)
+            && !candidate.IsValueType
+            && candidate.GetConstructor(Type.EmptyTypes) is null)
+        {
+            return false;
+        }
+
+        foreach (Type constraint in genericParameter.GetGenericParameterConstraints())
+        {
+            // Skip constraints that are themselves still open (none in our validators today).
+            if (constraint.ContainsGenericParameters)
+            {
+                continue;
+            }
+
+            if (!constraint.IsAssignableFrom(candidate))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/IntegratoR.OData.FO/Domain/Entities/LedgerJournal/LedgerJournalHeader.cs
+++ b/IntegratoR.OData.FO/Domain/Entities/LedgerJournal/LedgerJournalHeader.cs
@@ -38,8 +38,11 @@ public class LedgerJournalHeader : BaseEntity
     /// <summary>
     /// The identifier for the Journal Name setup. This is a crucial field as it governs the journal's behavior,
     /// including default values, number sequences, posting restrictions, and workflow configurations.
+    /// It is set at creation and read-only thereafter — D365 rejects updating it with an
+    /// ODataSecurityException — so it is excluded from the update payload.
     /// </summary>
     [JsonPropertyName("JournalName")]
+    [ODataField(IgnoreOnUpdate = true)]
     public virtual required string JournalName { get; set; }
 
     /// <summary>
@@ -66,24 +69,30 @@ public class LedgerJournalHeader : BaseEntity
     /// A read-only status flag indicating whether the journal has been successfully posted to the general ledger.
     /// </summary>
     [JsonPropertyName("IsPosted")]
+    [ODataField(IgnoreOnUpdate = true)]
     public virtual NoYes IsPosted { get; set; }
 
     /// <summary>
     /// A read-only, system-calculated field showing the total of all debit amounts from the journal lines.
     /// </summary>
     [JsonPropertyName("JournalTotalDebit")]
+    [ODataField(IgnoreOnUpdate = true)]
     public virtual decimal JournalTotalDebit { get; set; }
 
     /// <summary>
     /// A read-only, system-calculated field showing the total of all credit amounts from the journal lines.
     /// </summary>
     [JsonPropertyName("JournalTotalCredit")]
+    [ODataField(IgnoreOnUpdate = true)]
     public virtual decimal JournalTotalCredit { get; set; }
 
     /// <summary>
-    /// The accounting currency of the legal entity, which is the base currency for the journal's transactions. This is typically a read-only field.
+    /// The accounting currency of the legal entity, which is the base currency for the journal's transactions.
+    /// This is a read-only field in D365 — updating it is rejected with an ODataSecurityException, so it is
+    /// excluded from the update payload.
     /// </summary>
     [JsonPropertyName("AccountingCurrency")]
+    [ODataField(IgnoreOnUpdate = true)]
     public virtual string? AccountingCurrency { get; set; }
 
     /// <summary>

--- a/IntegratoR.OData/Common/Services/ODataService.cs
+++ b/IntegratoR.OData/Common/Services/ODataService.cs
@@ -157,9 +157,15 @@ public class ODataService<TEntity> : IODataService<TEntity>, IODataBatchService<
 
                 var payload = CreatePayload(entity, isCreateOperation: false);
 
-                return await _client
+                TEntity? updated = await _client
                     .UpdateAsync<TEntity>(_entitySetName, key, payload, cancellationToken)
                     .ConfigureAwait(false);
+
+                // A composite-key PATCH may return 204 No Content (D365 does not echo the entity), so
+                // the adapter yields null. The update succeeded — return the caller's entity so a
+                // successful Result<TEntity> always carries a non-null value rather than tripping
+                // consumers on a null Value.
+                return updated ?? entity;
             },
             entityKey: () => entity.GetCompositeKey(),
             cancellationToken: cancellationToken);

--- a/IntegratoR.SampleFunction/Endpoints/LedgerJournalSmokeTestTrigger.cs
+++ b/IntegratoR.SampleFunction/Endpoints/LedgerJournalSmokeTestTrigger.cs
@@ -477,10 +477,13 @@ public sealed class LedgerJournalSmokeTestTrigger
     {
         if (result.IsSuccess)
         {
+            // result.Value can be null on a successful write whose server response carried no body
+            // (e.g. an OData 204 No Content), so guard before invoking the onSuccess projector — a
+            // diagnostic trigger must never NRE and lose every per-step result to a 500.
             return new SmokeTestStep(
                 name,
                 Success: true,
-                Details: onSuccess?.Invoke(result.Value));
+                Details: result.Value is not null ? onSuccess?.Invoke(result.Value) : null);
         }
 
         IntegrationError? error = result.GetError();

--- a/tests/IntegratoR.Abstractions.Tests/Common/CQRS/Commands/CqrsCommandRecordTests.cs
+++ b/tests/IntegratoR.Abstractions.Tests/Common/CQRS/Commands/CqrsCommandRecordTests.cs
@@ -137,6 +137,58 @@ public sealed class CqrsCommandRecordTests
     }
 
     /// <summary>
+    /// Null-safe regression: a null Entity is a permitted (invalid) state that ValidationBehaviour
+    /// rejects — but LoggingBehaviour reads the logging context FIRST, so GetLoggingContext must NOT
+    /// throw. It returns a fallback carrying the entity type name instead of dereferencing the null.
+    /// </summary>
+    [Fact]
+    public void CreateCommand_GetLoggingContext_NullEntity_ReturnsTypeFallbackWithoutThrowing()
+    {
+        var command = new CreateCommand<TestEntity>(null!);
+
+        var context = command.GetLoggingContext();
+
+        context.Should().ContainKey("EntityType").WhoseValue.Should().Be(nameof(TestEntity));
+    }
+
+    /// <summary>Null-safe counterpart of <see cref="UpdateCommand_GetLoggingContext_DelegatesToEntity"/>.</summary>
+    [Fact]
+    public void UpdateCommand_GetLoggingContext_NullEntity_ReturnsTypeFallbackWithoutThrowing()
+    {
+        var command = new UpdateCommand<TestEntity>(null!);
+
+        var context = command.GetLoggingContext();
+
+        context.Should().ContainKey("EntityType").WhoseValue.Should().Be(nameof(TestEntity));
+    }
+
+    /// <summary>Null-safe counterpart of <see cref="DeleteCommand_GetLoggingContext_DelegatesToEntity"/>.</summary>
+    [Fact]
+    public void DeleteCommand_GetLoggingContext_NullEntity_ReturnsTypeFallbackWithoutThrowing()
+    {
+        var command = new DeleteCommand<TestEntity>(null!);
+
+        var context = command.GetLoggingContext();
+
+        context.Should().ContainKey("EntityType").WhoseValue.Should().Be(nameof(TestEntity));
+    }
+
+    /// <summary>
+    /// Null-safe regression for the batch commands: a null Entities collection must not throw when
+    /// LoggingBehaviour reads the context before validation rejects the command. (All three batch
+    /// commands share this implementation.)
+    /// </summary>
+    [Fact]
+    public void CreateBatchCommand_GetLoggingContext_NullEntities_ReturnsZeroCountWithoutThrowing()
+    {
+        var command = new CreateBatchCommand<TestEntity>(null!);
+
+        var context = command.GetLoggingContext();
+
+        context.Should().ContainKey("Count").WhoseValue.Should().Be(0);
+    }
+
+    /// <summary>
     /// Regression for the multiple-enumeration fix. The batch command ctor now takes
     /// <c>IReadOnlyList&lt;T&gt;</c> and <c>GetLoggingContext()</c> reads the O(1) <c>.Count</c> property
     /// instead of LINQ <c>Count()</c>, so it must not enumerate the sequence. This is pinned with a

--- a/tests/IntegratoR.Abstractions.Tests/Common/CQRS/Commands/CqrsCommandRecordTests.cs
+++ b/tests/IntegratoR.Abstractions.Tests/Common/CQRS/Commands/CqrsCommandRecordTests.cs
@@ -188,6 +188,28 @@ public sealed class CqrsCommandRecordTests
         context.Should().ContainKey("Count").WhoseValue.Should().Be(0);
     }
 
+    /// <summary>Null-safe counterpart for UpdateBatchCommand (shares the batch implementation).</summary>
+    [Fact]
+    public void UpdateBatchCommand_GetLoggingContext_NullEntities_ReturnsZeroCountWithoutThrowing()
+    {
+        var command = new UpdateBatchCommand<TestEntity>(null!);
+
+        var context = command.GetLoggingContext();
+
+        context.Should().ContainKey("Count").WhoseValue.Should().Be(0);
+    }
+
+    /// <summary>Null-safe counterpart for DeleteBatchCommand (shares the batch implementation).</summary>
+    [Fact]
+    public void DeleteBatchCommand_GetLoggingContext_NullEntities_ReturnsZeroCountWithoutThrowing()
+    {
+        var command = new DeleteBatchCommand<TestEntity>(null!);
+
+        var context = command.GetLoggingContext();
+
+        context.Should().ContainKey("Count").WhoseValue.Should().Be(0);
+    }
+
     /// <summary>
     /// Regression for the multiple-enumeration fix. The batch command ctor now takes
     /// <c>IReadOnlyList&lt;T&gt;</c> and <c>GetLoggingContext()</c> reads the O(1) <c>.Count</c> property

--- a/tests/IntegratoR.Hosting.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/tests/IntegratoR.Hosting.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -8,6 +8,7 @@ using IntegratoR.Abstractions.Common.Results;
 using IntegratoR.Abstractions.Domain.Entities;
 using IntegratoR.Abstractions.Interfaces.Authentication;
 using IntegratoR.Abstractions.Interfaces.Services;
+using IntegratoR.Application.Features.Common.Validators;
 using IntegratoR.OData.Domain.Settings;
 using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
 using IntegratoR.OData.FO.Domain.Models.Settings;
@@ -385,6 +386,72 @@ public class ServiceCollectionExtensionsTests
             result.Should().BeSuccessful();
             result.Value.Should().BeSameAs(header);
             await service.Received(1).GetByKeyAsync(key, Arg.Any<CancellationToken>());
+        }
+    }
+
+    [Fact]
+    public async Task AddIntegratoR_GenericCreateValidator_ShortCircuitsNullEntity_ThroughPipeline()
+    {
+        // Arrange
+        (ServiceProvider provider, IService<LedgerJournalHeader> service) = BuildProviderWithSubstitutedService();
+        await using (provider)
+        {
+            using IServiceScope scope = provider.CreateScope();
+            IMediator mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            // Act — a null entity must be rejected by the now-live CreateCommandValidator<LedgerJournalHeader>
+            // inside ValidationBehaviour and surface as a graceful Validation failure (NOT an NRE), even
+            // though LoggingBehaviour runs first and reads the command's logging context. (Pre-fix the
+            // generic validator was never registered AND the command's GetLoggingContext dereferenced
+            // the null entity, so this NRE'd in LoggingBehaviour before validation.)
+            Result<LedgerJournalHeader> result =
+                await mediator.Send(new CreateCommand<LedgerJournalHeader>(null!), TestContext.Current.CancellationToken);
+
+            // Assert
+            result.Should().BeFailed();
+            result.Should().HaveErrorType(ErrorType.Validation);
+            result.Should().HaveErrorCode("Validation.Error");
+            await service.DidNotReceive().AddAsync(Arg.Any<LedgerJournalHeader>(), Arg.Any<CancellationToken>());
+        }
+    }
+
+    [Fact]
+    public void AddIntegratoR_RegistersClosedGenericCommandValidator_ForFOEntity()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddIntegratoR(CreateMinimalConfiguration());
+
+        // Act
+        using ServiceProvider provider = services.BuildServiceProvider();
+        List<IValidator<CreateCommand<LedgerJournalHeader>>> validators =
+            provider.GetServices<IValidator<CreateCommand<LedgerJournalHeader>>>().ToList();
+
+        // Assert — TryAddEnumerable registers exactly one closed baseline validator for the entity.
+        validators.Should().ContainSingle()
+            .Which.Should().BeOfType<CreateCommandValidator<LedgerJournalHeader>>();
+    }
+
+    [Fact]
+    public async Task AddIntegratoR_GenericCreateBatchValidator_ShortCircuitsEmptyBatch_ThroughPipeline()
+    {
+        // Arrange
+        (ServiceProvider provider, IBatchService<LedgerJournalHeader> service) = BuildProviderWithSubstitutedBatchService();
+        await using (provider)
+        {
+            using IServiceScope scope = provider.CreateScope();
+            IMediator mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+            // Act — an empty batch must be rejected by the now-live CreateBatchCommandValidator's
+            // .Any() rule before the handler/service is reached.
+            Result result =
+                await mediator.Send(new CreateBatchCommand<LedgerJournalHeader>([]), TestContext.Current.CancellationToken);
+
+            // Assert
+            result.Should().BeFailed();
+            result.Should().HaveErrorType(ErrorType.Validation);
+            await service.DidNotReceive().AddBatchAsync(Arg.Any<IEnumerable<LedgerJournalHeader>>(), Arg.Any<CancellationToken>());
         }
     }
 

--- a/tests/IntegratoR.Hosting.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/tests/IntegratoR.Hosting.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -612,15 +612,14 @@ public class ServiceCollectionExtensionsTests
         }
     }
 
-    // Pinned behaviour for PR-C: AddIntegratoR now registers the F&O FluentValidation validators
-    // (step 6). GetDimensionOrdersQueryValidator — a non-generic validator — therefore fires in the
-    // MediatR ValidationBehaviour: an invalid (empty DimensionFormat) query is short-circuited with
-    // a Validation failure before the handler runs. (NOTE: open-generic validators such as the
-    // generic CreateCommandValidator<T> and the thin per-command derived validators are NOT
-    // discoverable by AddValidatorsFromAssembly, so generic command validation does not run through
-    // the pipeline today — a pre-existing framework-wide limitation, see the PR-C report. The
-    // derived validators are unit-proven against the concrete FO commands in
-    // GenericValidatorReuseTests.)
+    // Pinned behaviour: AddIntegratoR registers the F&O FluentValidation validators (step 6) AND
+    // closes the open-generic command/query validators over the discovered entities (step 6b), so
+    // generic command validation now runs through the pipeline. GetDimensionOrdersQueryValidator — a
+    // non-generic validator — fires in the MediatR ValidationBehaviour: an invalid (empty
+    // DimensionFormat) query is short-circuited with a Validation failure before the handler runs.
+    // (The open-generic CreateCommandValidator<T> etc. are now live too — proven by
+    // AddIntegratoR_GenericCreateValidator_ShortCircuitsNullEntity_ThroughPipeline and
+    // AddIntegratoR_RegistersClosedGenericCommandValidator_ForFOEntity above.)
     [Fact]
     public async Task AddIntegratoR_ValidationBehaviour_FiresFOValidator_ForGetDimensionOrdersQuery()
     {

--- a/tests/IntegratoR.OData.FO.Tests/Domain/Entities/LedgerJournal/LedgerJournalHeaderTests.cs
+++ b/tests/IntegratoR.OData.FO.Tests/Domain/Entities/LedgerJournal/LedgerJournalHeaderTests.cs
@@ -1,4 +1,6 @@
+using System.Reflection;
 using FluentAssertions;
+using IntegratoR.OData.Common.Annotations;
 using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
 using Xunit;
 
@@ -81,5 +83,28 @@ public class LedgerJournalHeaderTests
         context.Should().ContainKey(nameof(LedgerJournalHeader.JournalBatchNumber));
         context.Should().ContainKey(nameof(LedgerJournalHeader.JournalName));
         context.Should().ContainKey(nameof(LedgerJournalHeader.Description));
+    }
+
+    /// <summary>
+    /// Regression pin (live JFI smoke test 2026-07-01): these header fields are read-only in D365 —
+    /// updating any of them is rejected with an ODataSecurityException ("update not allowed for
+    /// field …", HTTP 403). They must carry <c>[ODataField(IgnoreOnUpdate = true)]</c> so
+    /// <c>CreatePayload</c> excludes them from the update payload.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(LedgerJournalHeader.JournalName))]
+    [InlineData(nameof(LedgerJournalHeader.AccountingCurrency))]
+    [InlineData(nameof(LedgerJournalHeader.IsPosted))]
+    [InlineData(nameof(LedgerJournalHeader.JournalTotalDebit))]
+    [InlineData(nameof(LedgerJournalHeader.JournalTotalCredit))]
+    public void ReadOnlyField_CarriesIgnoreOnUpdate(string propertyName)
+    {
+        PropertyInfo? property = typeof(LedgerJournalHeader).GetProperty(propertyName);
+
+        property.Should().NotBeNull();
+        ODataFieldAttribute? attribute = property!.GetCustomAttribute<ODataFieldAttribute>();
+
+        attribute.Should().NotBeNull($"{propertyName} is read-only in D365 and must be excluded from update payloads");
+        attribute!.IgnoreOnUpdate.Should().BeTrue();
     }
 }

--- a/tests/IntegratoR.OData.FO.Tests/Integration/Fakes/StatefulD365Handler.cs
+++ b/tests/IntegratoR.OData.FO.Tests/Integration/Fakes/StatefulD365Handler.cs
@@ -1,0 +1,582 @@
+using System.Globalization;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace IntegratoR.OData.FO.Tests.Integration.Fakes;
+
+/// <summary>
+/// A stateful, in-process fake of a D365 F&amp;O OData endpoint, wired as the primary
+/// <see cref="HttpMessageHandler"/> behind the named <c>"ODataClient"</c> HttpClient so the full
+/// pipeline (auth handler -&gt; Polly no-op -&gt; this fake) drives a real create/read/update/delete
+/// cycle against an in-memory store. It is the automated equivalent of a live D365 sandbox.
+/// </summary>
+/// <remarks>
+/// The store models the two LedgerJournal entity sets used by the integration test:
+/// <list type="bullet">
+///   <item><description><c>LedgerJournalHeaders</c>, keyed by <c>dataAreaId</c> + <c>JournalBatchNumber</c>.</description></item>
+///   <item><description><c>LedgerJournalLines</c>, keyed by <c>dataAreaId</c> + <c>JournalBatchNumber</c> + <c>LineNumber</c>.</description></item>
+/// </list>
+/// Server-assigned keys mimic D365 number sequences: a header POST is given a fresh
+/// <c>JournalBatchNumber</c> ("LNR0000001", "LNR0000002", …) and a line POST is given a per-batch
+/// decimal <c>LineNumber</c> (1, 2, …).
+///
+/// <para>
+/// Any request whose method + URL shape is not recognised <b>throws</b> with the absolute URL so a
+/// PanoramicData wire-format surprise surfaces as a diagnostic failure rather than silently wrong
+/// behaviour. Every request (method + absolute URL + body) is also captured on
+/// <see cref="Requests"/> for assertion.
+/// </para>
+/// </remarks>
+public sealed class StatefulD365Handler : HttpMessageHandler
+{
+    private const string HeaderSet = "LedgerJournalHeaders";
+    private const string LineSet = "LedgerJournalLines";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    // Composite-key -> stored entity (a mutable JSON object). Insertion order is preserved so GET
+    // filter results are returned deterministically.
+    private readonly Dictionary<string, JsonObject> _headers = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, JsonObject> _lines = new(StringComparer.Ordinal);
+
+    private int _headerCounter;
+    private readonly Dictionary<string, decimal> _lineCountersByBatch = new(StringComparer.Ordinal);
+
+    private readonly List<CapturedRequest> _requests = new();
+
+    /// <summary>Every request observed by the fake, in send order.</summary>
+    public IReadOnlyList<CapturedRequest> Requests => _requests;
+
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        string absoluteUrl = request.RequestUri!.AbsoluteUri;
+        string? body = request.Content is null
+            ? null
+            : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        _requests.Add(new CapturedRequest(request.Method, absoluteUrl, body));
+
+        // Path after the OData service root, e.g. "LedgerJournalHeaders" or
+        // "LedgerJournalHeaders(dataAreaId='1210',JournalBatchNumber='LNR0000001')".
+        string path = Uri.UnescapeDataString(request.RequestUri.AbsolutePath);
+        string lastSegment = path[(path.LastIndexOf('/') + 1)..];
+        string query = request.RequestUri.Query; // includes leading '?'
+
+        // PanoramicData may probe $metadata before typed operations. Serve a minimal valid CSDL so
+        // the typed model can resolve; if it never asks, this arm is simply never hit.
+        if (lastSegment.Equals("$metadata", StringComparison.OrdinalIgnoreCase))
+        {
+            return Xml(MinimalMetadata);
+        }
+
+        // Keyed segment "EntitySet(field=literal,...)" — used by PATCH/DELETE (the composite-key
+        // write bypass) and, in principle, a keyed GET (the framework does NOT issue keyed GETs;
+        // composite reads go through $filter, handled below).
+        int parenIndex = lastSegment.IndexOf('(');
+        if (parenIndex >= 0)
+        {
+            string entitySet = lastSegment[..parenIndex];
+            string keySegment = lastSegment[(parenIndex + 1)..].TrimEnd(')');
+            IReadOnlyDictionary<string, string> keyFields = ParseKeySegment(keySegment);
+
+            return request.Method.Method switch
+            {
+                "PATCH" => HandlePatch(entitySet, keyFields, body, absoluteUrl, request.Method),
+                "DELETE" => HandleDelete(entitySet, keyFields),
+                "GET" => HandleKeyedGet(entitySet, keyFields),
+                _ => throw Unrecognised(request.Method, absoluteUrl),
+            };
+        }
+
+        // Collection segment "EntitySet" — POST (create) and GET (filter).
+        return request.Method.Method switch
+        {
+            "POST" => HandlePost(lastSegment, body, absoluteUrl, request.Method),
+            "GET" => HandleFilterGet(lastSegment, query, absoluteUrl, request.Method),
+            _ => throw Unrecognised(request.Method, absoluteUrl),
+        };
+    }
+
+    // ----- POST (create) ---------------------------------------------------------------------
+
+    private HttpResponseMessage HandlePost(string entitySet, string? body, string url, HttpMethod method)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            throw Unrecognised(method, url, "POST with no body");
+        }
+
+        JsonObject entity = ParseObject(body, url);
+
+        if (entitySet.Equals(HeaderSet, StringComparison.Ordinal))
+        {
+            string dataAreaId = RequireString(entity, "dataAreaId", url);
+            string jbn = $"LNR{(++_headerCounter):D7}";
+            entity["JournalBatchNumber"] = jbn;
+
+            string key = HeaderKey(dataAreaId, jbn);
+            _headers[key] = entity;
+            return Json(HttpStatusCode.Created, entity.ToJsonString());
+        }
+
+        if (entitySet.Equals(LineSet, StringComparison.Ordinal))
+        {
+            string dataAreaId = RequireString(entity, "dataAreaId", url);
+            string jbn = RequireString(entity, "JournalBatchNumber", url);
+
+            string batchKey = HeaderKey(dataAreaId, jbn);
+            decimal next = _lineCountersByBatch.TryGetValue(batchKey, out decimal current) ? current + 1m : 1m;
+            _lineCountersByBatch[batchKey] = next;
+            entity["LineNumber"] = next;
+
+            // D365 returns the FULL row, including fields the client omitted from the create payload
+            // because they are server-assigned/read-only (IgnoreOnCreate). The client entity declares
+            // AccountDisplayValue and TransDate as required, so the create response must carry them or
+            // STJ's required-property check fails on the round-trip. Backfill the values D365 echoes.
+            entity.TryAdd("AccountDisplayValue", string.Empty);
+            entity.TryAdd("TransDate", DateTimeOffset.UnixEpoch.ToString("O"));
+
+            string key = LineKey(dataAreaId, jbn, next);
+            _lines[key] = entity;
+            return Json(HttpStatusCode.Created, entity.ToJsonString());
+        }
+
+        throw Unrecognised(method, url, $"POST to unknown entity set '{entitySet}'");
+    }
+
+    // ----- GET (filter) ----------------------------------------------------------------------
+
+    private HttpResponseMessage HandleFilterGet(string entitySet, string query, string url, HttpMethod method)
+    {
+        Dictionary<string, JsonObject> store = StoreFor(entitySet, method, url);
+
+        IReadOnlyDictionary<string, string> queryParams = ParseQuery(query);
+        queryParams.TryGetValue("$filter", out string? filter);
+        int? top = queryParams.TryGetValue("$top", out string? topValue)
+                   && int.TryParse(topValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedTop)
+            ? parsedTop
+            : null;
+
+        IEnumerable<JsonObject> matches = store.Values;
+        if (!string.IsNullOrWhiteSpace(filter))
+        {
+            IReadOnlyList<FilterClause> clauses = ParseFilter(filter!, url);
+            matches = matches.Where(entity => clauses.All(clause => Matches(entity, clause)));
+        }
+
+        if (top.HasValue)
+        {
+            matches = matches.Take(top.Value);
+        }
+
+        var array = new JsonArray();
+        foreach (JsonObject match in matches)
+        {
+            array.Add(Clone(match));
+        }
+
+        var envelope = new JsonObject
+        {
+            ["@odata.context"] = $"https://fake.local/data/$metadata#{entitySet}",
+            ["value"] = array,
+        };
+
+        return Json(HttpStatusCode.OK, envelope.ToJsonString());
+    }
+
+    // ----- GET (keyed) -----------------------------------------------------------------------
+
+    private HttpResponseMessage HandleKeyedGet(string entitySet, IReadOnlyDictionary<string, string> keyFields)
+    {
+        Dictionary<string, JsonObject> store = entitySet.Equals(HeaderSet, StringComparison.Ordinal)
+            ? _headers
+            : _lines;
+
+        string key = KeyFromSegment(entitySet, keyFields);
+        return store.TryGetValue(key, out JsonObject? entity)
+            ? Json(HttpStatusCode.OK, entity.ToJsonString())
+            : Json(HttpStatusCode.NotFound, "{\"error\":{\"code\":\"NotFound\",\"message\":\"Not found\"}}");
+    }
+
+    // ----- PATCH (update) --------------------------------------------------------------------
+
+    private HttpResponseMessage HandlePatch(
+        string entitySet,
+        IReadOnlyDictionary<string, string> keyFields,
+        string? body,
+        string url,
+        HttpMethod method)
+    {
+        Dictionary<string, JsonObject> store = entitySet.Equals(HeaderSet, StringComparison.Ordinal)
+            ? _headers
+            : _lines;
+
+        string key = KeyFromSegment(entitySet, keyFields);
+        if (!store.TryGetValue(key, out JsonObject? stored))
+        {
+            return Json(HttpStatusCode.NotFound, "{\"error\":{\"code\":\"NotFound\",\"message\":\"Not found\"}}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(body))
+        {
+            JsonObject patch = ParseObject(body!, url);
+            foreach (KeyValuePair<string, JsonNode?> property in patch)
+            {
+                stored[property.Key] = property.Value is null ? null : property.Value.DeepClone();
+            }
+        }
+
+        return Json(HttpStatusCode.OK, stored.ToJsonString());
+    }
+
+    // ----- DELETE ----------------------------------------------------------------------------
+
+    private HttpResponseMessage HandleDelete(string entitySet, IReadOnlyDictionary<string, string> keyFields)
+    {
+        Dictionary<string, JsonObject> store = entitySet.Equals(HeaderSet, StringComparison.Ordinal)
+            ? _headers
+            : _lines;
+
+        string key = KeyFromSegment(entitySet, keyFields);
+        store.Remove(key);
+        return new HttpResponseMessage(HttpStatusCode.NoContent);
+    }
+
+    // ----- Key helpers -----------------------------------------------------------------------
+
+    private static string HeaderKey(string dataAreaId, string jbn) => $"{dataAreaId}|{jbn}";
+
+    private static string LineKey(string dataAreaId, string jbn, decimal lineNumber)
+        => $"{dataAreaId}|{jbn}|{lineNumber.ToString(CultureInfo.InvariantCulture)}";
+
+    private static string KeyFromSegment(string entitySet, IReadOnlyDictionary<string, string> keyFields)
+    {
+        string dataAreaId = keyFields["dataAreaId"];
+        string jbn = keyFields["JournalBatchNumber"];
+
+        if (entitySet.Equals(HeaderSet, StringComparison.Ordinal))
+        {
+            return HeaderKey(dataAreaId, jbn);
+        }
+
+        decimal lineNumber = decimal.Parse(keyFields["LineNumber"], CultureInfo.InvariantCulture);
+        return LineKey(dataAreaId, jbn, lineNumber);
+    }
+
+    private Dictionary<string, JsonObject> StoreFor(string entitySet, HttpMethod method, string url)
+    {
+        if (entitySet.Equals(HeaderSet, StringComparison.Ordinal))
+        {
+            return _headers;
+        }
+
+        if (entitySet.Equals(LineSet, StringComparison.Ordinal))
+        {
+            return _lines;
+        }
+
+        throw Unrecognised(method, url, $"unknown entity set '{entitySet}'");
+    }
+
+    // ----- Parsing ---------------------------------------------------------------------------
+
+    // Splits "dataAreaId='1210',JournalBatchNumber='LNR0000001'" (or with an unquoted decimal
+    // LineNumber=1) into field -> literal-value (quotes stripped). Respects single-quoted strings so
+    // a comma inside a value would not split incorrectly.
+    private static Dictionary<string, string> ParseKeySegment(string segment)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (string part in SplitTopLevel(segment, ','))
+        {
+            int eq = part.IndexOf('=');
+            if (eq < 0)
+            {
+                continue;
+            }
+
+            string field = part[..eq].Trim();
+            string value = StripQuotes(part[(eq + 1)..].Trim());
+            result[field] = value;
+        }
+
+        return result;
+    }
+
+    // Parses an OData $filter of the form "<clause> and <clause> and ..." where each clause is
+    // "<field> eq <literal>" (string literals single-quoted, decimals unquoted). Field names are the
+    // wire names, including the camelCase dataAreaId.
+    private static IReadOnlyList<FilterClause> ParseFilter(string filter, string url)
+    {
+        // PanoramicData wraps the whole expression in a single pair of parentheses, e.g.
+        // "(dataAreaId eq '1210' and JournalBatchNumber eq 'LNR0000001')". Strip a balanced
+        // enclosing pair (outside any string literal) before splitting on " and ".
+        string normalised = StripEnclosingParens(filter.Trim());
+
+        var clauses = new List<FilterClause>();
+        foreach (string clause in SplitOnKeyword(normalised, " and "))
+        {
+            string trimmed = clause.Trim();
+            int eqIndex = trimmed.IndexOf(" eq ", StringComparison.Ordinal);
+            if (eqIndex < 0)
+            {
+                throw new InvalidOperationException(
+                    $"StatefulD365Handler could not parse $filter clause '{trimmed}' (URL: {url}). " +
+                    "Only '<field> eq <literal>' clauses joined by ' and ' are supported.");
+            }
+
+            string field = trimmed[..eqIndex].Trim();
+            string literal = trimmed[(eqIndex + 4)..].Trim();
+            clauses.Add(new FilterClause(field, StripQuotes(literal), IsQuoted(literal)));
+        }
+
+        return clauses;
+    }
+
+    private static bool Matches(JsonObject entity, FilterClause clause)
+    {
+        if (!entity.TryGetPropertyValue(clause.Field, out JsonNode? node) || node is null)
+        {
+            return false;
+        }
+
+        string actual = node.GetValueKind() == JsonValueKind.String
+            ? node.GetValue<string>()
+            : node.ToJsonString();
+
+        if (clause.IsString)
+        {
+            return string.Equals(actual, clause.Value, StringComparison.Ordinal);
+        }
+
+        // Numeric comparison so "1" matches a stored 1 regardless of decimal formatting.
+        return decimal.TryParse(actual, NumberStyles.Any, CultureInfo.InvariantCulture, out decimal actualNumber)
+               && decimal.TryParse(clause.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out decimal expectedNumber)
+               && actualNumber == expectedNumber;
+    }
+
+    private static IReadOnlyDictionary<string, string> ParseQuery(string query)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (string.IsNullOrEmpty(query))
+        {
+            return result;
+        }
+
+        foreach (string pair in query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            int eq = pair.IndexOf('=');
+            if (eq < 0)
+            {
+                continue;
+            }
+
+            string name = Uri.UnescapeDataString(pair[..eq]);
+            string value = Uri.UnescapeDataString(pair[(eq + 1)..]);
+            result[name] = value;
+        }
+
+        return result;
+    }
+
+    private static JsonObject ParseObject(string json, string url)
+    {
+        JsonNode? node = JsonNode.Parse(json);
+        return node as JsonObject
+               ?? throw new InvalidOperationException(
+                   $"StatefulD365Handler expected a JSON object body but got '{json}' (URL: {url}).");
+    }
+
+    private static string RequireString(JsonObject entity, string field, string url)
+    {
+        if (!entity.TryGetPropertyValue(field, out JsonNode? node) || node is null)
+        {
+            throw new InvalidOperationException(
+                $"StatefulD365Handler expected payload to contain '{field}' but it was missing (URL: {url}). " +
+                $"Body: {entity.ToJsonString()}");
+        }
+
+        return node.GetValue<string>();
+    }
+
+    // ----- Low-level string helpers ----------------------------------------------------------
+
+    private static IEnumerable<string> SplitTopLevel(string input, char separator)
+    {
+        var current = new StringBuilder();
+        bool inQuotes = false;
+        foreach (char c in input)
+        {
+            if (c == '\'')
+            {
+                inQuotes = !inQuotes;
+                current.Append(c);
+            }
+            else if (c == separator && !inQuotes)
+            {
+                yield return current.ToString();
+                current.Clear();
+            }
+            else
+            {
+                current.Append(c);
+            }
+        }
+
+        if (current.Length > 0)
+        {
+            yield return current.ToString();
+        }
+    }
+
+    // Splits on a keyword (e.g. " and ") that is NOT inside a single-quoted string literal.
+    private static IEnumerable<string> SplitOnKeyword(string input, string keyword)
+    {
+        var segments = new List<string>();
+        var current = new StringBuilder();
+        bool inQuotes = false;
+
+        for (int i = 0; i < input.Length; i++)
+        {
+            char c = input[i];
+            if (c == '\'')
+            {
+                inQuotes = !inQuotes;
+                current.Append(c);
+                continue;
+            }
+
+            if (!inQuotes
+                && i + keyword.Length <= input.Length
+                && input.AsSpan(i, keyword.Length).SequenceEqual(keyword))
+            {
+                segments.Add(current.ToString());
+                current.Clear();
+                i += keyword.Length - 1;
+                continue;
+            }
+
+            current.Append(c);
+        }
+
+        segments.Add(current.ToString());
+        return segments;
+    }
+
+    // Removes one balanced enclosing pair of parentheses (ignoring parens inside string literals)
+    // when the entire expression is wrapped, e.g. "(a eq '1' and b eq '2')" -> "a eq '1' and b eq '2'".
+    private static string StripEnclosingParens(string expression)
+    {
+        while (expression.Length >= 2 && expression[0] == '(' && expression[^1] == ')')
+        {
+            int depth = 0;
+            bool inQuotes = false;
+            bool wrapsWhole = true;
+
+            for (int i = 0; i < expression.Length; i++)
+            {
+                char c = expression[i];
+                if (c == '\'')
+                {
+                    inQuotes = !inQuotes;
+                }
+                else if (!inQuotes && c == '(')
+                {
+                    depth++;
+                }
+                else if (!inQuotes && c == ')')
+                {
+                    depth--;
+                    // The opening paren closed before the end — it does not wrap the whole string.
+                    if (depth == 0 && i != expression.Length - 1)
+                    {
+                        wrapsWhole = false;
+                        break;
+                    }
+                }
+            }
+
+            if (!wrapsWhole)
+            {
+                break;
+            }
+
+            expression = expression[1..^1].Trim();
+        }
+
+        return expression;
+    }
+
+    private static bool IsQuoted(string literal)
+        => literal.Length >= 2 && literal[0] == '\'' && literal[^1] == '\'';
+
+    private static string StripQuotes(string literal)
+        => IsQuoted(literal) ? literal[1..^1].Replace("''", "'") : literal;
+
+    private static JsonObject Clone(JsonObject source) => (JsonObject)source.DeepClone();
+
+    // ----- Responses -------------------------------------------------------------------------
+
+    private static HttpResponseMessage Json(HttpStatusCode status, string json)
+        => new(status) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    private static HttpResponseMessage Xml(string xml)
+        => new(HttpStatusCode.OK) { Content = new StringContent(xml, Encoding.UTF8, "application/xml") };
+
+    private static InvalidOperationException Unrecognised(HttpMethod method, string url, string? detail = null)
+        => new(
+            $"StatefulD365Handler received an unrecognised request: {method} {url}" +
+            (detail is null ? "." : $" ({detail})."));
+
+    // Minimal CSDL covering both entity sets, served only if PanoramicData probes $metadata.
+    private const string MinimalMetadata =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+          <edmx:DataServices>
+            <Schema Namespace="Microsoft.Dynamics.DataEntities" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+              <EntityType Name="LedgerJournalHeader">
+                <Key>
+                  <PropertyRef Name="dataAreaId" />
+                  <PropertyRef Name="JournalBatchNumber" />
+                </Key>
+                <Property Name="dataAreaId" Type="Edm.String" Nullable="false" />
+                <Property Name="JournalBatchNumber" Type="Edm.String" Nullable="false" />
+                <Property Name="JournalName" Type="Edm.String" />
+                <Property Name="Description" Type="Edm.String" />
+              </EntityType>
+              <EntityType Name="LedgerJournalLine">
+                <Key>
+                  <PropertyRef Name="dataAreaId" />
+                  <PropertyRef Name="JournalBatchNumber" />
+                  <PropertyRef Name="LineNumber" />
+                </Key>
+                <Property Name="dataAreaId" Type="Edm.String" Nullable="false" />
+                <Property Name="JournalBatchNumber" Type="Edm.String" Nullable="false" />
+                <Property Name="LineNumber" Type="Edm.Decimal" Nullable="false" />
+                <Property Name="DebitAmount" Type="Edm.Decimal" />
+                <Property Name="CreditAmount" Type="Edm.Decimal" />
+                <Property Name="CurrencyCode" Type="Edm.String" />
+                <Property Name="Text" Type="Edm.String" />
+              </EntityType>
+              <EntityContainer Name="Resources">
+                <EntitySet Name="LedgerJournalHeaders" EntityType="Microsoft.Dynamics.DataEntities.LedgerJournalHeader" />
+                <EntitySet Name="LedgerJournalLines" EntityType="Microsoft.Dynamics.DataEntities.LedgerJournalLine" />
+              </EntityContainer>
+            </Schema>
+          </edmx:DataServices>
+        </edmx:Edmx>
+        """;
+
+    /// <summary>A single request observed by the fake.</summary>
+    public sealed record CapturedRequest(HttpMethod Method, string Url, string? Body);
+
+    private sealed record FilterClause(string Field, string Value, bool IsString);
+}

--- a/tests/IntegratoR.OData.FO.Tests/Integration/Fakes/StatefulD365Handler.cs
+++ b/tests/IntegratoR.OData.FO.Tests/Integration/Fakes/StatefulD365Handler.cs
@@ -234,7 +234,11 @@ public sealed class StatefulD365Handler : HttpMessageHandler
             }
         }
 
-        return Json(HttpStatusCode.OK, stored.ToJsonString());
+        // D365 answers a PATCH with 204 No Content (it does not echo the entity unless asked via
+        // Prefer: return=representation), so the store is mutated but no body is returned. Mirroring
+        // that here exercises ODataService.UpdateAsync's null-result handling — a 200+body would
+        // have masked the live 204-No-Content bug this test now guards against.
+        return new HttpResponseMessage(HttpStatusCode.NoContent);
     }
 
     // ----- DELETE ----------------------------------------------------------------------------

--- a/tests/IntegratoR.OData.FO.Tests/Integration/LedgerJournalCrudIntegrationTests.cs
+++ b/tests/IntegratoR.OData.FO.Tests/Integration/LedgerJournalCrudIntegrationTests.cs
@@ -1,0 +1,215 @@
+using FluentAssertions;
+using FluentResults;
+using IntegratoR.Abstractions.Common.CQRS.Commands;
+using IntegratoR.Abstractions.Common.CQRS.Queries;
+using IntegratoR.Abstractions.Common.Results;
+using IntegratoR.OData.FO.Domain.Entities.LedgerJournal;
+using IntegratoR.OData.FO.Tests.Integration.Fakes;
+using IntegratoR.TestKit.Assertions;
+using MediatR;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace IntegratoR.OData.FO.Tests.Integration;
+
+/// <summary>
+/// An automated end-to-end integration test that drives the full create -&gt; read -&gt; update -&gt;
+/// delete pipeline for a D365 F&amp;O <see cref="LedgerJournalHeader"/> (and its
+/// <see cref="LedgerJournalLine"/> children) through <see cref="IMediator"/> against an in-process
+/// stateful fake OData endpoint (<see cref="StatefulD365Handler"/>). It exercises the
+/// composite-key WRITE bypass (PATCH/DELETE to keyed URLs) and proves each read observes the prior
+/// write — the automated equivalent of a live JFI smoke run.
+/// </summary>
+public sealed class LedgerJournalCrudIntegrationTests : IDisposable
+{
+    private const string DataAreaId = "1210";
+
+    private readonly StatefulD365Handler _fake;
+    private readonly ServiceProvider _provider;
+    private readonly IMediator _mediator;
+
+    public LedgerJournalCrudIntegrationTests()
+    {
+        _fake = new StatefulD365Handler();
+
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ODataSettings:Url"] = "https://fake.local/data",
+                ["ODataSettings:Authentication:Mode"] = "ApiKey",
+                ["ODataSettings:Authentication:ApiManagement:SubscriptionKey"] = "test-key",
+                ["ODataSettings:Authentication:ApiManagement:SubscriptionHeaderKey"] = "Ocp-Apim-Subscription-Key",
+                ["ODataSettings:Resilience:EnableRetries"] = "false",
+                ["ODataSettings:Resilience:UseCircuitBreaker"] = "false",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddIntegratoR(config);
+
+        // Swap the named client's primary handler for the stateful fake AFTER AddIntegratoR so
+        // requests flow: ODataAuthenticationHandler -> Polly (no-op) -> fake.
+        services.AddHttpClient("ODataClient").ConfigurePrimaryHttpMessageHandler(() => _fake);
+
+        _provider = services.BuildServiceProvider();
+        _mediator = _provider.GetRequiredService<IMediator>();
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => _provider.Dispose();
+
+    [Fact]
+    public async Task FullCrudCycle_DrivesCreateReadUpdateDelete_ThroughCompositeKeyBypass()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        // 1. CREATE the header — JournalBatchNumber is server-assigned (IgnoreOnCreate).
+        var header = new LedgerJournalHeader
+        {
+            DataAreaId = DataAreaId,
+            JournalName = "GenJrn",
+            Description = "SMOKETEST",
+        };
+
+        Result<LedgerJournalHeader> createHeaderResult =
+            await _mediator.Send(new CreateCommand<LedgerJournalHeader>(header), cancellationToken);
+
+        createHeaderResult.Should().BeSuccessful();
+        createHeaderResult.Value.JournalBatchNumber.Should().NotBeNullOrEmpty();
+        string jbn = createHeaderResult.Value.JournalBatchNumber!;
+
+        // 2. READ the header back by composite key (routes through a $filter, not a keyed GET).
+        Result<LedgerJournalHeader> getHeaderResult =
+            await _mediator.Send(new GetByKeyQuery<LedgerJournalHeader>([DataAreaId, jbn]), cancellationToken);
+
+        getHeaderResult.Should().BeSuccessful();
+        getHeaderResult.Value.Description.Should().Be("SMOKETEST");
+
+        // 3. READ by filter — the camelCase dataAreaId filter must emit dataAreaId eq '1210'.
+        Result<IEnumerable<LedgerJournalHeader>> filterHeaderResult = await _mediator.Send(
+            new GetByFilterQuery<LedgerJournalHeader>(
+                x => x.DataAreaId == DataAreaId && x.JournalBatchNumber == jbn),
+            cancellationToken);
+
+        filterHeaderResult.Should().BeSuccessful();
+        filterHeaderResult.Value.Should().ContainSingle();
+
+        // 4. CREATE two lines (debit then credit). LineNumber is server-assigned (IgnoreOnCreate).
+        //    AccountDisplayValue/TransDate are required by the compiler contract even though
+        //    IgnoreOnCreate strips them from the create payload.
+        var debitLine = new LedgerJournalLine
+        {
+            DataAreaId = DataAreaId,
+            JournalBatchNumber = jbn,
+            AccountDisplayValue = "110110",
+            DebitAmount = 100m,
+            CreditAmount = 0m,
+            CurrencyCode = "EUR",
+            TransDate = DateTimeOffset.UtcNow,
+        };
+
+        var creditLine = new LedgerJournalLine
+        {
+            DataAreaId = DataAreaId,
+            JournalBatchNumber = jbn,
+            AccountDisplayValue = "110120",
+            DebitAmount = 0m,
+            CreditAmount = 100m,
+            CurrencyCode = "EUR",
+            TransDate = DateTimeOffset.UtcNow,
+        };
+
+        Result<LedgerJournalLine> createDebitResult =
+            await _mediator.Send(new CreateCommand<LedgerJournalLine>(debitLine), cancellationToken);
+        Result<LedgerJournalLine> createCreditResult =
+            await _mediator.Send(new CreateCommand<LedgerJournalLine>(creditLine), cancellationToken);
+
+        createDebitResult.Should().BeSuccessful();
+        createCreditResult.Should().BeSuccessful();
+        createDebitResult.Value.LineNumber.Should().Be(1m);
+        createCreditResult.Value.LineNumber.Should().Be(2m);
+        decimal lineNumber = createDebitResult.Value.LineNumber;
+
+        // 5. READ the lines by filter — both lines belong to the batch.
+        Result<IEnumerable<LedgerJournalLine>> filterLinesResult = await _mediator.Send(
+            new GetByFilterQuery<LedgerJournalLine>(
+                x => x.DataAreaId == DataAreaId && x.JournalBatchNumber == jbn),
+            cancellationToken);
+
+        filterLinesResult.Should().BeSuccessful();
+        filterLinesResult.Value.Should().HaveCount(2);
+
+        // 6. UPDATE the header (composite-key bypass PATCH) and re-read to prove persistence.
+        header.JournalBatchNumber = jbn;
+        header.Description = "SMOKETEST-UPDATED";
+
+        Result<LedgerJournalHeader> updateHeaderResult =
+            await _mediator.Send(new UpdateCommand<LedgerJournalHeader>(header), cancellationToken);
+
+        updateHeaderResult.Should().BeSuccessful();
+
+        Result<LedgerJournalHeader> rereadHeaderResult =
+            await _mediator.Send(new GetByKeyQuery<LedgerJournalHeader>([DataAreaId, jbn]), cancellationToken);
+
+        rereadHeaderResult.Should().BeSuccessful();
+        rereadHeaderResult.Value.Description.Should().Be("SMOKETEST-UPDATED");
+
+        // 7. UPDATE a line (composite-key bypass PATCH) and re-read by key to prove persistence.
+        debitLine.LineNumber = lineNumber;
+        debitLine.TransactionText = "SMOKE-UPDATED";
+
+        Result<LedgerJournalLine> updateLineResult =
+            await _mediator.Send(new UpdateCommand<LedgerJournalLine>(debitLine), cancellationToken);
+
+        updateLineResult.Should().BeSuccessful();
+
+        Result<LedgerJournalLine> rereadLineResult =
+            await _mediator.Send(new GetByKeyQuery<LedgerJournalLine>([DataAreaId, jbn, lineNumber]), cancellationToken);
+
+        rereadLineResult.Should().BeSuccessful();
+        rereadLineResult.Value.TransactionText.Should().Be("SMOKE-UPDATED");
+
+        // 8. DELETE each line, then the header (composite-key bypass DELETE).
+        Result<LedgerJournalLine> deleteDebitResult =
+            await _mediator.Send(new DeleteCommand<LedgerJournalLine>(debitLine), cancellationToken);
+        Result<LedgerJournalLine> deleteCreditResult =
+            await _mediator.Send(new DeleteCommand<LedgerJournalLine>(new LedgerJournalLine
+            {
+                DataAreaId = DataAreaId,
+                JournalBatchNumber = jbn,
+                LineNumber = createCreditResult.Value.LineNumber,
+                AccountDisplayValue = "110120",
+                CurrencyCode = "EUR",
+                TransDate = DateTimeOffset.UtcNow,
+            }), cancellationToken);
+
+        deleteDebitResult.Should().BeSuccessful();
+        deleteCreditResult.Should().BeSuccessful();
+
+        Result<LedgerJournalHeader> deleteHeaderResult =
+            await _mediator.Send(new DeleteCommand<LedgerJournalHeader>(header), cancellationToken);
+
+        deleteHeaderResult.Should().BeSuccessful();
+
+        // 9. READ the header again — it must now be gone (NotFound after the delete).
+        Result<LedgerJournalHeader> goneResult =
+            await _mediator.Send(new GetByKeyQuery<LedgerJournalHeader>([DataAreaId, jbn]), cancellationToken);
+
+        goneResult.Should().BeFailed();
+        goneResult.Should().HaveErrorType(ErrorType.NotFound);
+
+        // The bypass PATCH and DELETE must have hit the keyed composite-key URLs.
+        string headerKeySegment = $"(dataAreaId='{DataAreaId}',JournalBatchNumber='{jbn}')";
+        _fake.Requests.Should().Contain(r =>
+            r.Method == HttpMethod.Patch && r.Url.Contains(headerKeySegment));
+        _fake.Requests.Should().Contain(r =>
+            r.Method == HttpMethod.Delete && r.Url.Contains(headerKeySegment));
+        _fake.Requests.Should().Contain(r =>
+            r.Method == HttpMethod.Patch
+            && r.Url.Contains($"dataAreaId='{DataAreaId}'")
+            && r.Url.Contains($"JournalBatchNumber='{jbn}'")
+            && r.Url.Contains("LineNumber="));
+    }
+}

--- a/tests/IntegratoR.OData.FO.Tests/IntegratoR.OData.FO.Tests.csproj
+++ b/tests/IntegratoR.OData.FO.Tests/IntegratoR.OData.FO.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\IntegratoR.Hosting\IntegratoR.Hosting.csproj" />
     <ProjectReference Include="..\..\IntegratoR.OData.FO\IntegratoR.OData.FO.csproj" />
     <ProjectReference Include="..\IntegratoR.TestKit\IntegratoR.TestKit.csproj" />
   </ItemGroup>

--- a/tests/IntegratoR.OData.Tests/Common/Services/ODataServiceTests.cs
+++ b/tests/IntegratoR.OData.Tests/Common/Services/ODataServiceTests.cs
@@ -183,6 +183,31 @@ public class ODataServiceTests
     }
 
     /// <summary>
+    /// Regression: a composite-key PATCH that returns 204 No Content makes the adapter yield null.
+    /// The update still succeeded, so UpdateAsync must return the caller's entity rather than a
+    /// successful Result carrying a null Value (which previously NRE'd consumers reading it).
+    /// </summary>
+    [Fact]
+    public async Task UpdateAsync_AdapterReturnsNull_ReturnsSuccessWithInputEntity()
+    {
+        // Arrange — the adapter returns null, mimicking a 204 No Content response with no body.
+        var entity = TestEntityBuilder.Default().Build();
+        _client.UpdateAsync<TestEntity>(
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>())
+            .Returns((TestEntity)null!);
+
+        // Act
+        var result = await _sut.UpdateAsync(entity, CancellationToken.None);
+
+        // Assert
+        result.Should().BeSuccessful();
+        result.Value.Should().BeSameAs(entity);
+    }
+
+    /// <summary>
     /// Verifies that UpdateAsync with a null entity returns a validation error immediately.
     /// </summary>
     [Fact]


### PR DESCRIPTION
Closes the last two open follow-ups (open-todos #15, #2's live verification) and hardens the composite-key write path based on a **fully-green live JFI smoke run**.

## 1. Activate generic command validation (open-todos #15)
FluentValidation's `AddValidatorsFromAssembly` skips open generics, so `IValidator<CreateCommand<T>>` was never registered and generic command validation **silently never ran**. `AddIntegratoR` now closes every open-generic command/query validator over the discovered entity types (F&O + consumer assemblies) and registers the closed `IValidator<>` via `TryAddEnumerable`. Proven end-to-end through the pipeline (null entity / empty batch short-circuit before the handler).

Fixing this surfaced a **real latent bug**: `LoggingBehaviour` runs before `ValidationBehaviour` and called `request.GetLoggingContext()`, which dereferenced a null command entity → NRE *before* validation could reject it. The six generic commands' `GetLoggingContext()` are now null-safe (matching the existing `GetByKeyQuery` precedent).

## 2. Automated CRUD integration test
A stateful in-process fake D365 (`StatefulD365Handler`) wired behind the named `"ODataClient"` client; one test drives the full create → read → filter → update → re-read → delete → verify-gone lifecycle through `IMediator`, exercising the composite-key write bypass. Reads observe the writes from the same store; the fake throws (not silently passes) on any unrecognised request shape.

## 3. Composite-key write hardening — found by a live JFI run
Running the `LedgerJournalSmokeTestTrigger` against live JFI went **fully green for the first time** (LNR0000300 created→updated→deleted→verified-gone, self-cleaned). It uncovered three genuine bugs no unit test caught:
- **204 No Content → null Value** — a composite-key PATCH returns 204 (D365 doesn't echo the entity), so the bypass yielded null and a *successful* `UpdateAsync` returned `Result.Ok(null)`. `ODataService.UpdateAsync` now returns the caller's entity on a null adapter result.
- **Read-only header fields leaked into updates** — D365 403'd (`ODataSecurityException "update not allowed for field …"`) on `AccountingCurrency`, then `JournalName`. `JournalName`/`AccountingCurrency`/`IsPosted`/`JournalTotalDebit`/`JournalTotalCredit` are now `[ODataField(IgnoreOnUpdate = true)]` (same class as the 2026-04 `CurrencyCode` bug).
- **Trigger NRE→500** — `BuildStep`'s `onSuccess` crashed the whole invocation on the null Value; now guarded.

The integration-test fake was updated to answer PATCH with **204** like real D365, closing the fidelity gap that hid the first bug.

## Review findings
This branch already had an adversarial review pass; its findings are addressed (stale "validators never fire" comment updated; `UpdateBatch`/`DeleteBatch` null-safety pins added; F&O-derived-validator registration documented as benign).

## Semver
All bug fixes, non-breaking → next release is **v2.0.1** (GitVersion increments PATCH from the v2.0.0 tag; no marker needed).

## Risks / rollback
Validation now runs framework-wide for generic commands — the dispatch audit (re-done independently in review) found **zero** currently-dispatched command that a now-live validator rejects. The entity `IgnoreOnUpdate` change only narrows update payloads (create unaffected). Per-fix commits are atomic and individually revertible.

## Verification
`dotnet build` clean; `dotnet test` → **579 passed, 0 failed**. Live JFI LedgerJournal smoke test: **all 14 steps green** (create/read/filter/update/verify/delete/verify-gone), self-cleaned. (Orphans `LNR0000297`/`298` remain from two pre-fix diagnostic crash runs — flagged for cleanup.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)