### PR TITLE
docs: composite-key writes are live + v2.0.1 learnings

### DIFF
--- a/.claude/rules/odata-conventions.md
+++ b/.claude/rules/odata-conventions.md
@@ -11,11 +11,12 @@
 
 ## Entity Patterns
 
-- Entities inherit from `BaseEntity<TKey>` and must implement `GetCompositeKey()`.
+- Entities inherit from the non-generic `BaseEntity` and must implement `GetCompositeKey()`. (`BaseEntity<TKey>` is `[Obsolete]` — the `TKey` parameter was never used; removed next MAJOR.)
 - D365 uses composite keys: typically `DataAreaId` + business key.
 - `[Table("EntitySetName")]` maps to OData entity sets.
 - `[ODataField(IgnoreOnCreate = true)]` for server-generated fields (e.g., `JournalBatchNumber`, `LineNumber`).
-- `[ODataField(IgnoreOnUpdate = true)]` for immutable fields.
+- `[ODataField(IgnoreOnUpdate = true)]` for fields that are **read-only on update** in D365 — not only immutable business keys but also server-computed / status fields. If ANY such field is present in the update payload, D365 rejects the **whole** PATCH with an `ODataSecurityException` (HTTP 403, `"update not allowed for field 'X'"`), not just that field. Verified against live JFI (2026-07-01): `LedgerJournalHeader` needed `AccountingCurrency`, `IsPosted`, `JournalTotalDebit`, `JournalTotalCredit`, and `JournalName` marked `IgnoreOnUpdate`. When adding an entity, audit every field against D365's update semantics.
+- Composite-key **writes** (Update/Delete/batch) are live via an owned raw-`HttpClient` bypass in `ODataClientAdapter` (D365 returns `204 No Content` on a composite-key PATCH, so `ODataService.UpdateAsync` returns the caller's entity — a successful `Result<TEntity>` never carries a null `Value`).
 - Before writing code examples with D365 entities, read the entity source to check which fields have `IgnoreOnCreate`/`IgnoreOnUpdate`.
 
 ## Property Naming and `[JsonPropertyName]`

--- a/wiki/Define-Entities.md
+++ b/wiki/Define-Entities.md
@@ -41,17 +41,17 @@ public class LedgerJournalHeader : BaseEntity<string>
 Three contracts make this entity work end-to-end:
 
 1. **`[Table("LedgerJournalHeaders")]`** maps the class to the D365 OData entity set. The name is **case-sensitive** and almost always **plural** — `LedgerJournalHeader` is the entity, `LedgerJournalHeaders` is the entity set.
-2. **`BaseEntity<TKey>`** declares the abstract `GetCompositeKey()` that handlers use for composite-key URL construction and reflection-based structured logging via `GetLoggingContext()`.
+2. **`BaseEntity`** declares the abstract `GetCompositeKey()` that handlers use for composite-key URL construction and reflection-based structured logging via `GetLoggingContext()`.
 3. **`[Key]` plus `GetCompositeKey()`** define which properties form the primary key and the order in which the framework passes them to OData reads.
 
 A hand-written entity's properties need **not** be `virtual` — the `virtual` requirement applies only when the entity will be subclassed and its properties overridden (see [Extend a Built-in Entity](#extend-a-built-in-entity) below).
 
-## BaseEntity\<TKey\>
+## BaseEntity
 
-`BaseEntity<TKey>` is an abstract base class in `IntegratoR.Abstractions.Domain.Entities`. The single type parameter is the primary-key data type — most D365 entities use `string` (the wire type for `DataAreaId`), but `int`, `long`, and `Guid` are equally valid:
+`BaseEntity` is the non-generic abstract base class in `IntegratoR.Abstractions.Domain.Entities`. Inherit it and implement `GetCompositeKey()` — the key is returned as an `object[]`, so one base class serves every key shape:
 
 ```csharp
-public class DimensionParameters : BaseEntity<int>
+public class DimensionParameters : BaseEntity
 {
     [Key]
     [JsonPropertyName("Key")]
@@ -61,7 +61,9 @@ public class DimensionParameters : BaseEntity<int>
 }
 ```
 
-`BaseEntity<TKey>` implements `IEntity` and `IContext`. Custom entities almost never need to extend either interface directly — inheriting from `BaseEntity` is sufficient.
+`BaseEntity` implements `IEntity` and `IContext`, so custom entities almost never need to extend either interface directly.
+
+> The older generic `BaseEntity<TKey>` is `[Obsolete]` — its `TKey` type parameter was never used (keys flow through `object[]`). It still compiles but is removed in the next MAJOR; derive new entities from the non-generic `BaseEntity`.
 
 ## Composite Keys
 
@@ -96,13 +98,15 @@ public decimal JournalTotalDebit { get; set; }      // fully read-only, calculat
 | Flag | Effect | Typical use |
 |---|---|---|
 | `IgnoreOnCreate = true` | Property is excluded from the POST payload | Number-sequence fields, computed totals, server defaults |
-| `IgnoreOnUpdate = true` | Property is excluded from the PATCH payload | Primary-key parts, immutable business keys |
+| `IgnoreOnUpdate = true` | Property is excluded from the PATCH payload | Primary-key parts, immutable business keys, and server-computed / read-only fields |
 
 The framework reads the attribute via reflection inside `ODataService<T>.AddAsync` / `UpdateAsync` and strips the matching properties from the JSON body. The consumer code can populate the full entity (including fields the server will overwrite); the framework filters at serialisation time.
 
 ### Common Pitfall
 
 Setting a field marked `IgnoreOnCreate = true` and then calling `CreateCommand<T>` silently drops the value. The record creates successfully but with the server's default instead of the supplied value. When in doubt, read the entity source for the `[ODataField]` annotations before populating the entity.
+
+Conversely, if an update payload contains **any** field D365 treats as read-only on update, D365 rejects the **entire** PATCH with an `ODataSecurityException` (HTTP 403, `"update not allowed for field 'X'"`) — not just that field. This covers server-computed and status fields, not only business keys (on `LedgerJournalHeader`: `AccountingCurrency`, `IsPosted`, `JournalTotalDebit`/`JournalTotalCredit`, and `JournalName`). Mark every such field `[ODataField(IgnoreOnUpdate = true)]` so it is stripped from the PATCH body. Verified against live JFI (v2.0.1).
 
 ### CSDL-Driven Annotations
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -34,7 +34,7 @@ A .NET 10 framework for building enterprise integrations with **Microsoft Dynami
 | [Understand the Architecture](Understand-the-Architecture) | Layer diagram, dependency flow, project map |
 | [Authentication Modes](Authentication-Modes) | OAuth 2.0 vs API Key (APIM), Key Vault integration |
 | [Set Up Azure Functions Host](Set-Up-Azure-Functions-Host) | Production `Program.cs`, Key Vault, Application Insights |
-| [Known Limitations](Known-Limitations) | Composite-key write paths, other parked items (transparent) |
+| [Known Limitations](Known-Limitations) | Remaining parked items, transparently tracked (composite-key writes are resolved as of v2.0.0) |
 | [Troubleshoot Common Issues](Troubleshoot-Common-Issues) | Real errors from sandbox runs and how to resolve them |
 | [Release Notes and Versioning](Release-Notes-and-Versioning) | Semantic versioning, pre-release vs stable, migration tips |
 

--- a/wiki/Known-Limitations.md
+++ b/wiki/Known-Limitations.md
@@ -2,7 +2,7 @@
 
 This page lists known constraints in the framework and the planned resolutions. The goal is transparency — every limitation here has been investigated, has a documented cause, and either has a tracked workaround or has a planned fix.
 
-> Last refreshed against v1.3.5.
+> Last refreshed against v2.0.1.
 
 ## Composite-Key Write Path — RESOLVED
 
@@ -35,7 +35,9 @@ This page lists known constraints in the framework and the planned resolutions. 
 
 ## Entity Attribute Audit Pending
 
-**What:** PR #92 fixed `CurrencyCode` on `LedgerJournalLine`, which had been simultaneously `[Required]` and `[ODataField(IgnoreOnCreate = true)]`. Six other fields on `LedgerJournalLine` carry the same suspect combination and have not been audited yet: `AccountDisplayValue`, `TransDate`, `DueDate`, `DocumentDate`, `ExchRate`, `ReverseDate`.
+**Fixed in v2.0.1 (`LedgerJournalHeader` read-only-on-update fields):** the live 2026-07-01 JFI run found D365 rejects the entire update PATCH with an `ODataSecurityException` (HTTP 403) whenever a read-only field rides in the payload. `LedgerJournalHeader`'s `JournalName`, `AccountingCurrency`, `IsPosted`, `JournalTotalDebit`, and `JournalTotalCredit` are now `[ODataField(IgnoreOnUpdate = true)]`, so composite-key `UpdateCommand<LedgerJournalHeader>` succeeds.
+
+**Still open — `LedgerJournalLine` `[Required]` + `IgnoreOnCreate` audit:** PR #92 fixed `CurrencyCode` on `LedgerJournalLine`, which had been simultaneously `[Required]` and `[ODataField(IgnoreOnCreate = true)]`. Six other fields on `LedgerJournalLine` carry the same suspect combination and have not been audited yet: `AccountDisplayValue`, `TransDate`, `DueDate`, `DocumentDate`, `ExchRate`, `ReverseDate`.
 
 **Symptoms:** none observed today on the smoke-test path. The bug shape is *silent payload exclusion of a required field*, which D365 may accept (computing a default) or reject (HTTP 400 from D365 with a server-side validation message) depending on the journal template and field.
 
@@ -63,7 +65,7 @@ The framework's backlog, tracked internally by maintainers, consolidates these i
 
 ## See Also
 
-- [Send Commands](Send-Commands) — composite-key Update/Delete limitation referenced from the command pages
-- [Run Smoke Tests](Run-Smoke-Tests) — the smoke tests that surface the composite-key write issue
+- [Send Commands](Send-Commands) — composite-key Update/Delete, now via the owned write bypass
+- [Run Smoke Tests](Run-Smoke-Tests) — the smoke tests that verify composite-key writes work end to end
 - [Release Notes and Versioning](Release-Notes-and-Versioning) — when fixes ship
 - [Troubleshoot Common Issues](Troubleshoot-Common-Issues) — the operator-side view of the same incidents

--- a/wiki/Release-Notes-and-Versioning.md
+++ b/wiki/Release-Notes-and-Versioning.md
@@ -6,17 +6,19 @@ IntegratoR packages follow [Semantic Versioning](https://semver.org/) — `MAJOR
 
 | Trigger | Version produced | NuGet listing |
 |---|---|---|
-| Push to `main` (every PR squash-merge) | `1.X.Y-ci.N` pre-release | Pre-release, hidden by default in NuGet UI |
-| Manual workflow dispatch with `release: true` | `1.X.Y` stable | Stable, shown by default |
+| Push to `main` (every PR squash-merge) | `X.Y.Z-ci.N` pre-release | Pre-release, hidden by default in NuGet UI |
+| Manual workflow dispatch with `release: true` | `X.Y.Z` stable | Stable, shown by default |
 
-Both publish to `nuget.org`. Consumers pinning `1.3.5` pick up the stable version; consumers using a `*-*` range will see the latest pre-release. Choose the pin shape according to risk tolerance.
+Both publish to `nuget.org`. Consumers pinning an exact version (e.g. `2.0.0`) pick up the stable version; consumers using a `*-*` range will see the latest pre-release. Choose the pin shape according to risk tolerance.
 
-> **GitVersion defaults to PATCH bumps.** Conventional-commit prefixes (`feat:`, `fix:`, `chore:`) are **not** honoured for bump detection in the current `GitVersion.yml` configuration. Every merge produces a PATCH bump (1.3.4 → 1.3.5 → 1.3.6, ...). To force a MINOR or MAJOR bump, either include `+semver: minor` / `+semver: major` in the merge commit message, or bump `next-version:` in `GitVersion.yml` before merging.
+> **GitVersion defaults to PATCH bumps.** Conventional-commit prefixes (`feat:`, `fix:`, `chore:`) are **not** honoured for bump detection in the current `GitVersion.yml` configuration. Every merge produces a PATCH bump (2.0.0 → 2.0.1 → 2.0.2, ...). To force a MINOR or MAJOR bump, either include `+semver: minor` / `+semver: major` in the merge commit message, or bump `next-version:` in `GitVersion.yml` before merging.
 
 ## Released Versions
 
 | Version | Date | Highlights |
 |---|---|---|
+| v2.0.1 | next release | Composite-key write hardening from the live 2026-07-01 JFI run: `ODataService.UpdateAsync` returns the written entity when a composite-key PATCH comes back `204 No Content`; `LedgerJournalHeader` read-only fields (`JournalName`, `AccountingCurrency`, `IsPosted`, `JournalTotalDebit/Credit`) are now `[ODataField(IgnoreOnUpdate = true)]` so D365 no longer rejects the PATCH with an `ODataSecurityException`; the smoke trigger no longer crashes on a null success value. Generic command validation now runs through the MediatR pipeline (a null command / empty batch / empty composite key short-circuits with a Validation failure). |
+| v2.0.0 | 2026-06-30 | **Breaking** — architecture-review fix series (PRs #131–135). Composite-key **write** support (Update / Delete / batch) via an owned raw-`HttpClient` bypass in `ODataClientAdapter`. Strongly-typed `$orderby`. `ODataSettingsValidator` (`IValidateOptions` + `ValidateOnStart`). `IBatchService<T>` + generic batch handlers. 401/403 and OAuth-failure `ReasonPhrase`/message no longer leak MSAL/tenant detail. `FindEntriesAsync` gained an `orderBy` parameter; batch commands take `IReadOnlyList<T>`; `GetDimensionOrdersQuery` params PascalCased. `BaseEntity<TKey>`, `IODataService.FindAll`, `ODataBatchException`, `ICacheableQuery.GenerateCacheKey`/`GetCacheKeyValues`, `ODataMetadataProvider` deprecated. RELion module removed. |
 | v1.3.5 | 2026-05-13 | FinancialDimension smoke test + dimension query fixes (PR #104). Enum-constant qualified-type form in lambda bodies. `DimensionParameters.Key` `string → int`. `DimensionIntegrationFormat` table-name plural fix. |
 | v1.3.4 | 2026-04-15 | Smoke-test framework fixes (PR #92): MediatR cross-assembly handler closing, BaseAddress trailing-slash normalisation, ExceptionHandler 404 observability, `CurrencyCode` payload fix on `LedgerJournalLine`. |
 | v1.3.3 | (in series with PR #86) | `[JsonPropertyName]`-aware OData filter / select / expand translator (PR #86). camelCase wire names now honoured throughout the LINQ path. |

--- a/wiki/Run-Queries.md
+++ b/wiki/Run-Queries.md
@@ -19,7 +19,7 @@ if (result.IsSuccess)
 
 The framework builds an OData URL of the form `<Url>/<TableName>(field1='value1',field2='value2')`. Because D365 entity sets often use composite keys with mixed CLR types, the values are coerced to their OData literal form (strings quoted, integers bare, decimals with `M` suffix, dates as `datetimeoffset`).
 
-> The composite-key read path uses a `$filter`-based bypass internally rather than the OData `(key=value, ...)` segment, because PanoramicData.OData.Client lacks a composite-key write API. Reads work transparently; writes have a [Known Limitation](Known-Limitations#composite-key-writes).
+> The composite-key read path uses a `$filter`-based bypass internally rather than relying on the OData `(key=value, ...)` segment. Both reads and writes go through owned, first-party bypasses in `ODataClientAdapter` — reads via this `$filter` path, and writes (Update / Delete) via a raw-`HttpClient` keyed-URL bypass (since v2.0.0). Both use the named `"ODataClient"` client, so they carry the same authentication, Polly resilience, and `BaseAddress` as every other request. See [Send Commands](Send-Commands) for the write side.
 
 ## Filter Records
 

--- a/wiki/Run-Smoke-Tests.md
+++ b/wiki/Run-Smoke-Tests.md
@@ -8,8 +8,10 @@ Both triggers are part of the open-source sample project — clone the repositor
 
 | Trigger | Route | Operations | Side effects |
 |---|---|---|---|
-| `LedgerJournalSmokeTestTrigger` | `POST /api/smoke/ledger-journal` | Create → Get → Filter → Update → Delete on `LedgerJournalHeader` and `LedgerJournalLine` | Creates a real journal in D365; best-effort cleanup |
+| `LedgerJournalSmokeTestTrigger` | `POST /api/smoke/ledger-journal` | Create → Get → Filter → Update → Delete on `LedgerJournalHeader` and `LedgerJournalLine` | Creates a real journal in D365; deletes it again on the same run — self-cleaning, no orphan left behind |
 | `FinancialDimensionSmokeTestTrigger` | `POST /api/smoke/financial-dimensions` | `GetDimensionOrdersQuery` (one MediatR `Send` that chains two D365 reads) | **None** — read-only, safe to run repeatedly |
+
+Both triggers use `AuthorizationLevel.Function`. Running locally with `func start` no host key is required; once deployed to Azure they need a function/host key (`?code=<key>` or the `x-functions-key` header).
 
 The financial-dimension trigger is the recommended first run: it is read-only, depends on no company context, and verifies authentication + OData + the `[JsonPropertyName]` filter translator in one round-trip.
 
@@ -110,7 +112,7 @@ A failed response surfaces the `IntegrationError` per step:
 
 ## LedgerJournal Smoke Test
 
-The journal smoke test exercises the write path — composite-key creation, payload field exclusion via `[ODataField]`, balanced debit/credit line creation, update, and cleanup.
+The journal smoke test exercises the full write path end to end — composite-key creation, payload field exclusion via `[ODataField]`, balanced debit/credit line creation, **composite-key Update and Delete**, and re-read verification that each write landed. It was verified green against a live D365 (JFI) sandbox on 2026-07-01: the complete create → update → delete → verify-gone cycle passed and self-cleaned with no orphan record.
 
 ```bash
 curl -s -X POST http://localhost:7123/api/smoke/ledger-journal \
@@ -125,21 +127,27 @@ curl -s -X POST http://localhost:7123/api/smoke/ledger-journal \
      }'
 ```
 
-The trigger runs seven steps in order:
+The trigger runs the full ordered write-and-verify chain:
 
-| # | Step | What it proves |
-|---|---|---|
-| 1 | Create header | `CreateCommand<LedgerJournalHeader>` payload exclusion for `JournalBatchNumber` |
-| 2 | Get by composite key | `GetByKeyQuery<LedgerJournalHeader>` composite-key construction |
-| 3 | Filter by `dataAreaId` | `GetByFilterQuery` and the `[JsonPropertyName]`-aware filter translator |
-| 4 | Create debit line | `CreateCommand<LedgerJournalLine>` with the required `CurrencyCode` |
-| 5 | Create credit line | Same path, second line |
-| 6 | Filter lines by `dataAreaId` | Translator against `LedgerJournalLine` |
-| 7 | Cleanup (best effort) | Delete the lines and the header |
+| Step | What it proves |
+|---|---|
+| `CreateHeader` | `CreateCommand<LedgerJournalHeader>` payload exclusion for `JournalBatchNumber` |
+| `GetHeaderByKey` | `GetByKeyQuery<LedgerJournalHeader>` composite-key construction |
+| `FilterHeaderByDataAreaId` | `GetByFilterQuery` and the `[JsonPropertyName]`-aware filter translator |
+| `CreateDebitLine` | `CreateCommand<LedgerJournalLine>` with the required `CurrencyCode` |
+| `CreateCreditLine` | Same path, second line |
+| `FilterLinesByDataAreaId` | Translator against `LedgerJournalLine` |
+| `UpdateHeader` | `UpdateCommand<LedgerJournalHeader>` composite-key **PATCH** via the owned bypass |
+| `VerifyHeaderUpdated` | Re-reads the header by composite key and confirms the new `Description` |
+| `UpdateLine` | `UpdateCommand<LedgerJournalLine>` composite-key PATCH on the line |
+| `VerifyLineUpdated` | Re-reads the line and confirms the updated `TransactionText` |
+| `DeleteLine[…]` | `DeleteCommand<LedgerJournalLine>` composite-key **DELETE** per line |
+| `DeleteHeader` | `DeleteCommand<LedgerJournalHeader>` composite-key DELETE |
+| `VerifyHeaderDeleted` | Re-reads the header; a `NotFound` result confirms the delete landed |
 
 The response is the same per-step JSON shape as the financial-dimensions trigger.
 
-> Step 7 (cleanup delete) currently has a known limitation — composite-key Update/Delete writes go through a code path with a parked PanoramicData issue. The cleanup step reports success in the response but logs a `Warning` line on the host saying the delete may not have happened. The created journal stays in the D365 sandbox until manually removed via the UI. See [Known Limitations](Known-Limitations#composite-key-write-path) for the parked workaround.
+Composite-key Update and Delete run through the owned raw-`HttpClient` bypass in `ODataClientAdapter` (shipped in v2.0.0) — it builds the keyed URL manually, e.g. `LedgerJournalHeaders(dataAreaId='1210',JournalBatchNumber='LNR0000300')`, through the named `"ODataClient"` client so the write carries the same auth, Polly resilience, and `BaseAddress` as every other request. Because the chain deletes everything it creates and verifies the header is gone, a green run leaves no record behind.
 
 ## Diagnosing a Failed Smoke Test
 
@@ -161,7 +169,7 @@ Both triggers can be wired into a CI smoke pipeline that exercises a sandbox aft
 
 1. Deploy the framework to a sandbox slot
 2. Run the financial-dimension smoke test (read-only, fast, low-risk)
-3. Run the ledger-journal smoke test (writes a journal, accept the orphan record)
+3. Run the ledger-journal smoke test (writes a journal, then deletes it — self-cleaning, no orphan left behind)
 4. Block promotion to production if either step's `Success` is `false`
 
 The triggers signal failure via the JSON `Success` field, not the HTTP status code — the HTTP response is always 200 (unless the request body is malformed). CI scripts should check `.Success` against the response body (e.g. `jq -e '.Success'`), not rely on HTTP status alone.
@@ -169,6 +177,6 @@ The triggers signal failure via the JSON `Success` field, not the HTTP status co
 ## See Also
 
 - [Troubleshoot Common Issues](Troubleshoot-Common-Issues) — diagnostic guide for the error codes above
-- [Known Limitations](Known-Limitations) — composite-key write parking
+- [Known Limitations](Known-Limitations) — remaining open items (composite-key writes are resolved)
 - [Work with Dimensions](Work-with-Dimensions) — what the dimension smoke test exercises
 - [Send Commands](Send-Commands) — what the journal smoke test exercises

--- a/wiki/Send-Commands.md
+++ b/wiki/Send-Commands.md
@@ -41,7 +41,7 @@ Result<LedgerJournalHeader> result = await mediator.Send(
 
 `UpdateCommand<TEntity>` sends a PATCH to the composite-key URL. Fields marked `IgnoreOnUpdate` or with `AllowEdit = false` are excluded from the payload. The composite key on the entity must be fully populated — the framework reads `GetCompositeKey()` to build the key segment.
 
-> The composite-key URL for the update path has a known limitation in the current PanoramicData.OData.Client release — see [Known Limitations](Known-Limitations#composite-key-writes) for the parked workaround design. Reads via `GetByKeyQuery<T>` use a different code path that already handles composite keys via the `Filter()` bypass.
+> Composite-key writes work (since v2.0.0). When `ODataClientAdapter` sees a composite (dictionary) key it issues the PATCH through an owned, first-party raw-`HttpClient` bypass that builds the keyed URL manually — e.g. `LedgerJournalHeaders(dataAreaId='USMF',JournalBatchNumber='B0001')` — through the named `"ODataClient"` client, so the write carries the same authentication, Polly resilience, and `BaseAddress` as every other request. This mirrors the read-path bypass that `GetByKeyQuery<T>` already used.
 
 ## Delete a Record
 
@@ -51,7 +51,7 @@ Result<LedgerJournalHeader> result = await mediator.Send(
     cancellationToken).ConfigureAwait(false);
 ```
 
-The composite key on the entity must be populated. The same composite-key write limitation noted above applies.
+The composite key on the entity must be populated. `DeleteCommand<TEntity>` issues the DELETE through the same owned composite-key bypass described above.
 
 ## Batch Operations
 

--- a/wiki/Troubleshoot-Common-Issues.md
+++ b/wiki/Troubleshoot-Common-Issues.md
@@ -46,7 +46,7 @@ If the token is acquired but D365 still returns HTTP 401: register the app as a 
 
 D365 returned HTTP 404 because the request URL was malformed. Two common shapes:
 
-1. URL contains `(System.Collections.Generic.Dictionary…)` — the composite-key write-path limitation. See [Known Limitations](Known-Limitations#composite-key-write-path).
+1. URL contains `(System.Collections.Generic.Dictionary…)` — the **pre-v2.0.0** composite-key write path serialised the key dictionary via `Object.ToString()`. Fixed in v2.0.0: `ODataClientAdapter` now builds the keyed URL manually through an owned raw-`HttpClient` bypass. If you see this shape, upgrade to v2.0.0 or later. See [Known Limitations](Known-Limitations#composite-key-write-path--resolved).
 2. URL is missing a path segment (`/fo`, `/data`) — `BaseAddress` trailing-slash issue.
 
 **Resolution for (2):** ensure `ODataSettings.Url` ends with the correct path segment. The framework normalises by appending a trailing slash; either `https://host/fo` or `https://host/fo/` works. The host log emits `OData client configured with base URL: <normalised>` once at startup — verify the segment is present.
@@ -56,7 +56,7 @@ D365 returned HTTP 404 because the request URL was malformed. Two common shapes:
 The ExceptionHandler's observability fix (since v1.3.4) surfacing a suppressed-404. The Result returned to the consumer is still `Result.Ok` (the `treatNotFoundAsSuccess` flag), but the warning signals one of:
 
 - The entity was genuinely already gone (legitimate idempotent delete) — ignore the warning.
-- The request URL was malformed and D365 had nothing to match (composite-key write path) — see [Known Limitations](Known-Limitations#composite-key-write-path).
+- On a **pre-v2.0.0** build, the request URL was malformed and D365 had nothing to match (the old composite-key write path). Fixed in v2.0.0 — see [Known Limitations](Known-Limitations#composite-key-write-path--resolved).
 
 The warning includes the request URL — `RequestUrl: (internal)` means the framework could not capture it; `RequestUrl: <full-url>` lets the operator distinguish the two cases.
 
@@ -112,13 +112,15 @@ D365 rejected the line create because `CurrencyCode` was missing from the payloa
 
 **Resolution:** fixed in PR #92 (v1.3.4). The `CurrencyCode` attribute on `LedgerJournalLine` had `[ODataField(IgnoreOnCreate = true)]` removed — the value the consumer supplies now reaches the wire. Verify the consumer's code sets `CurrencyCode` on every line.
 
-### Step 6 (UpdateHeader) fails with `LedgerJournalHeader.NotFound: Resource not found: LedgerJournalHeaders(System.Collections.Generic.Dictionary…)`
+### `UpdateHeader` fails with `LedgerJournalHeader.NotFound: Resource not found: LedgerJournalHeaders(System.Collections.Generic.Dictionary…)`
 
-Composite-key write-path limitation. See [Known Limitations](Known-Limitations#composite-key-write-path).
+Historical (pre-v2.0.0) composite-key write-path bug — the key dictionary serialised via `Object.ToString()` into the URL. Fixed in v2.0.0: `ODataClientAdapter` now builds the keyed URL manually through the owned raw-`HttpClient` bypass, so `UpdateHeader`, `UpdateLine`, `DeleteLine`, and `DeleteHeader` all land against the correct record. If you see this, upgrade to v2.0.0 or later. See [Known Limitations](Known-Limitations#composite-key-write-path--resolved).
 
-### Step 7 (Cleanup.Delete*) returns success but the journal stays in D365
+> On v2.0.0, a composite-key PATCH that returns `204 No Content` made `ODataService.UpdateAsync` hand back a null `Value`, and D365 rejected a PATCH carrying a read-only `LedgerJournalHeader` field (`JournalName`, `AccountingCurrency`, `IsPosted`, `JournalTotalDebit/Credit`) with an `ODataSecurityException` (HTTP 403). Both are fixed in v2.0.1 — `UpdateAsync` returns the caller's entity and those fields are now `[ODataField(IgnoreOnUpdate = true)]`.
 
-Same composite-key write-path limitation surfaced via the suppressed-404 observability warning. The journal must be deleted manually via the D365 UI until the bypass ships.
+### `DeleteHeader` / cleanup returns success and the journal is removed
+
+On v2.0.0 and later the full Update/Delete cycle runs through the owned composite-key bypass and self-cleans — the smoke test deletes every line and the header it created and verifies the header is gone (`VerifyHeaderDeleted`). A green run leaves no orphan in D365. Verified end to end against a live D365 (JFI) sandbox on 2026-07-01.
 
 ## Extending the Framework
 

--- a/wiki/Understand-the-Architecture.md
+++ b/wiki/Understand-the-Architecture.md
@@ -91,10 +91,10 @@ Custom behaviours registered via `services.AddTransient(typeof(IPipelineBehavior
 D365 F&O entities are almost always keyed by `(DataAreaId, BusinessKey)`. The framework constructs OData composite-key URLs by:
 
 1. Reading `GetCompositeKey()` from the entity.
-2. For reads: building a `$filter` predicate with `eq` on each key field (this bypasses a limitation in PanoramicData.OData.Client — see [Known Limitations](Known-Limitations)).
-3. For writes: writing through PanoramicData's single-key `UpdateAsync` / `DeleteAsync` paths (this currently has the parked limitation — composite-key writes fall back to broken behaviour).
+2. For reads: building a `$filter` predicate with `eq` on each key field.
+3. For writes (Update / Delete, including the batch variants): `ODataClientAdapter` detects the composite (dictionary) key and issues the PATCH / DELETE through an owned raw-`HttpClient` bypass that builds the keyed URL manually — `LedgerJournalHeaders(dataAreaId='USMF',JournalBatchNumber='B0001')` — through the named `"ODataClient"` client so the write carries the same authentication, Polly resilience, and `BaseAddress` as every other request (since v2.0.0).
 
-The key-field **names** used in the URL are the `[JsonPropertyName]` wire names (camelCase `dataAreaId`, not CLR `DataAreaId`), because that is what D365 OData expects.
+Both the read and write bypasses are owned, first-party source maintained in this repository. The key-field **names** used in the URL are the `[JsonPropertyName]` wire names (camelCase `dataAreaId`, not CLR `DataAreaId`), because that is what D365 OData expects.
 
 ### Two JSON Serialisers
 


### PR DESCRIPTION
Documentation-only. Removes the now-false "composite-key write path is parked/broken" claims across the wiki and the `odata-conventions` rule, and records the learnings from the fully-green live JFI smoke run.

## What changed
- **Composite-key writes are live (v2.0.0):** swept `Run-Queries`, `Send-Commands`, `Understand-the-Architecture`, `Troubleshoot-Common-Issues`, `Home`, `Known-Limitations` — Update/Delete work via the owned raw-HttpClient bypass, verified end-to-end against live JFI on 2026-07-01. Old malformed-URL troubleshooting kept but reframed as "fixed in v2.0.0".
- **`Run-Smoke-Tests`:** replaced the stale 7-step table + "accept the orphan" note with the full ordered Create->Update->Delete->verify chain (self-cleaning, no orphan); noted `AuthorizationLevel.Function`.
- **v2.0.1 learnings recorded:** a composite-key PATCH returns 204 No Content so `UpdateAsync` returns the written entity; read-only header fields must be `IgnoreOnUpdate` or D365 403s the whole PATCH; generic command validation is now active.
- **Stale-stat refresh:** "Last refreshed against v1.3.5" -> v2.0.1; `Define-Entities` now teaches the non-generic `BaseEntity` (was the `[Obsolete]` `BaseEntity<TKey>`).

Still-open limitations (Polly-400, `LedgerJournalLine` attribute audit, cross-company, advanced `$expand`, `IValidateOptions`) are preserved.

## Verification
Docs-only; no code touched. Full suite green (579 tests). Wiki conventions preserved (every page keeps its See Also).

🤖 Generated with [Claude Code](https://claude.com/claude-code)