### PR TITLE
feat(batch): batch outcome types + settings (foundation for OData $batch redesign)

### DIFF
--- a/IntegratoR.Abstractions/Common/Batch/BatchFailureMode.cs
+++ b/IntegratoR.Abstractions/Common/Batch/BatchFailureMode.cs
@@ -1,0 +1,19 @@
+namespace IntegratoR.Abstractions.Common.Batch;
+
+/// <summary>
+/// Controls how a batch write behaves when one of its operations fails.
+/// </summary>
+public enum BatchFailureMode
+{
+    /// <summary>
+    /// All operations in a chunk run as a single OData changeset: either every operation commits
+    /// or, if any fails, none of them are applied (all-or-nothing per chunk).
+    /// </summary>
+    Atomic = 0,
+
+    /// <summary>
+    /// Operations are applied independently: a failure does not stop the others, and the per-item
+    /// outcome of every operation is reported so failed records can be identified and retried.
+    /// </summary>
+    ContinueOnError = 1,
+}

--- a/IntegratoR.Abstractions/Common/Batch/BatchItemResult.cs
+++ b/IntegratoR.Abstractions/Common/Batch/BatchItemResult.cs
@@ -1,0 +1,44 @@
+namespace IntegratoR.Abstractions.Common.Batch;
+
+/// <summary>
+/// The outcome of a single operation within a batch write, carrying enough detail to identify and
+/// re-drive a failed record during an import.
+/// </summary>
+public sealed record BatchItemResult
+{
+    /// <summary>
+    /// Gets the zero-based position of this operation in the original input sequence, across all chunks.
+    /// </summary>
+    public required int Index { get; init; }
+
+    /// <summary>
+    /// Gets the zero-based index of the chunk this operation was submitted in.
+    /// </summary>
+    public required int ChunkIndex { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the operation completed successfully (an HTTP 2xx status).
+    /// </summary>
+    public required bool IsSuccess { get; init; }
+
+    /// <summary>
+    /// Gets the HTTP status code D365 returned for this operation.
+    /// </summary>
+    public required int StatusCode { get; init; }
+
+    /// <summary>
+    /// Gets the composite key of the record the operation targeted (wire field names to values), or
+    /// <c>null</c> for a create whose key D365 assigns server-side.
+    /// </summary>
+    public IReadOnlyDictionary<string, object>? Key { get; init; }
+
+    /// <summary>
+    /// Gets the machine-readable D365 inner-error code for a failed operation, if one was returned.
+    /// </summary>
+    public string? ErrorCode { get; init; }
+
+    /// <summary>
+    /// Gets the human-readable error message for a failed operation, if any.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+}

--- a/IntegratoR.Abstractions/Common/Batch/BatchOptions.cs
+++ b/IntegratoR.Abstractions/Common/Batch/BatchOptions.cs
@@ -1,0 +1,19 @@
+namespace IntegratoR.Abstractions.Common.Batch;
+
+/// <summary>
+/// Per-call overrides for a single batch write. A <c>null</c> member falls back to the configured
+/// <c>ODataSettings.Batch</c> default.
+/// </summary>
+public sealed record BatchOptions
+{
+    /// <summary>
+    /// Gets the failure mode for this call, or <c>null</c> to use the configured default.
+    /// </summary>
+    public BatchFailureMode? Mode { get; init; }
+
+    /// <summary>
+    /// Gets the maximum number of operations per chunk for this call, or <c>null</c> to use the
+    /// configured default. Must be between 1 and 5000 (D365's documented maximum per <c>$batch</c>).
+    /// </summary>
+    public int? MaxOperationsPerChunk { get; init; }
+}

--- a/IntegratoR.Abstractions/Common/Batch/BatchOutcome.cs
+++ b/IntegratoR.Abstractions/Common/Batch/BatchOutcome.cs
@@ -1,0 +1,53 @@
+namespace IntegratoR.Abstractions.Common.Batch;
+
+/// <summary>
+/// The aggregate result of a batch write across every chunk, listing the per-item outcome so callers
+/// can report which records committed and which failed.
+/// </summary>
+/// <remarks>
+/// A batch that failed is returned as a failed <see cref="FluentResults.Result{T}"/> whose error is a
+/// <c>BatchIntegrationError</c> carrying this outcome, so the failure list is available even when
+/// <see cref="FluentResults.ResultBase.IsSuccess"/> is <c>false</c>.
+/// </remarks>
+public sealed record BatchOutcome
+{
+    /// <summary>
+    /// Gets the failure mode the batch ran under.
+    /// </summary>
+    public required BatchFailureMode Mode { get; init; }
+
+    /// <summary>
+    /// Gets the number of chunks the input was split into and submitted as separate <c>$batch</c> requests.
+    /// </summary>
+    public required int ChunkCount { get; init; }
+
+    /// <summary>
+    /// Gets the per-item outcome of every submitted operation, in original input order.
+    /// </summary>
+    public required IReadOnlyList<BatchItemResult> Items { get; init; }
+
+    /// <summary>
+    /// Gets the total number of operations submitted.
+    /// </summary>
+    public int Total => Items.Count;
+
+    /// <summary>
+    /// Gets the number of operations that committed successfully.
+    /// </summary>
+    public int Succeeded => Items.Count(item => item.IsSuccess);
+
+    /// <summary>
+    /// Gets the number of operations that failed.
+    /// </summary>
+    public int Failed => Items.Count(item => !item.IsSuccess);
+
+    /// <summary>
+    /// Gets a value indicating whether every operation committed successfully.
+    /// </summary>
+    public bool AllSucceeded => Failed == 0;
+
+    /// <summary>
+    /// Gets the operations that failed, for error analysis and retry.
+    /// </summary>
+    public IEnumerable<BatchItemResult> Failures => Items.Where(item => !item.IsSuccess);
+}

--- a/IntegratoR.Abstractions/Common/Results/BatchIntegrationError.cs
+++ b/IntegratoR.Abstractions/Common/Results/BatchIntegrationError.cs
@@ -1,0 +1,29 @@
+using IntegratoR.Abstractions.Common.Batch;
+
+namespace IntegratoR.Abstractions.Common.Results;
+
+/// <summary>
+/// The header error of a failed batch write. Carries the full <see cref="BatchOutcome"/> so the
+/// per-item failure list is retrievable from a failed <see cref="FluentResults.Result{T}"/> via
+/// <c>result.GetError()</c>.
+/// </summary>
+public sealed class BatchIntegrationError : IntegrationError
+{
+    /// <summary>
+    /// Gets the aggregate batch outcome, including the per-item success and failure detail.
+    /// </summary>
+    public BatchOutcome Outcome { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BatchIntegrationError"/> class.
+    /// </summary>
+    /// <param name="code">The machine-readable error code.</param>
+    /// <param name="message">The human-readable summary (e.g. "3 of 200 operations failed").</param>
+    /// <param name="outcome">The aggregate batch outcome carrying per-item detail.</param>
+    /// <param name="type">The category used for HTTP status mapping. Defaults to <see cref="ErrorType.Failure"/>.</param>
+    public BatchIntegrationError(string code, string message, BatchOutcome outcome, ErrorType type = ErrorType.Failure)
+        : base(code, message, type)
+    {
+        Outcome = outcome;
+    }
+}

--- a/IntegratoR.OData/Domain/Settings/ODataBatchSettings.cs
+++ b/IntegratoR.OData/Domain/Settings/ODataBatchSettings.cs
@@ -1,0 +1,47 @@
+using IntegratoR.Abstractions.Common.Batch;
+
+namespace IntegratoR.OData.Domain.Settings;
+
+/// <summary>
+/// Configures how the OData client submits batch writes: the default failure mode, automatic
+/// chunking, and how a failed chunk affects the rest of the dataset.
+/// </summary>
+public class ODataBatchSettings
+{
+    /// <summary>
+    /// Gets or sets the default failure mode for batch writes when a call does not override it.
+    /// </summary>
+    /// <value>The default value is <see cref="BatchFailureMode.Atomic"/>.</value>
+    public BatchFailureMode FailureMode { get; set; } = BatchFailureMode.Atomic;
+
+    /// <summary>
+    /// Gets or sets the maximum number of operations sent in a single <c>$batch</c> request; larger
+    /// datasets are split into consecutive chunks.
+    /// </summary>
+    /// <remarks>
+    /// D365 documents a hard maximum of 5000 operations per <c>$batch</c>; the default of 150 is a
+    /// conservative value chosen to stay clear of execution-time and resource throttling, not a
+    /// Microsoft-published recommendation.
+    /// </remarks>
+    /// <value>The default value is <c>150</c>.</value>
+    public int MaxOperationsPerChunk { get; set; } = 150;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether, in <see cref="BatchFailureMode.Atomic"/> mode, the
+    /// remaining chunks are skipped once a chunk fails.
+    /// </summary>
+    /// <value>The default value is <c>true</c>.</value>
+    public bool StopOnFirstFailedChunk { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether <see cref="BatchFailureMode.ContinueOnError"/> is sent
+    /// as a single <c>$batch</c> with the <c>Prefer: odata.continue-on-error</c> header rather than as
+    /// independent per-item requests.
+    /// </summary>
+    /// <remarks>
+    /// D365 F&amp;O does not document support for <c>odata.continue-on-error</c>, so this is disabled
+    /// by default until verified against a live environment.
+    /// </remarks>
+    /// <value>The default value is <c>false</c>.</value>
+    public bool UseServerContinueOnError { get; set; }
+}

--- a/IntegratoR.OData/Domain/Settings/ODataSettings.cs
+++ b/IntegratoR.OData/Domain/Settings/ODataSettings.cs
@@ -31,4 +31,9 @@ public class ODataSettings
     /// Gets or sets the resilience settings (retry and circuit breaker) for the OData client.
     /// </summary>
     public ODataResilienceSettings Resilience { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the batch write settings (failure mode and automatic chunking) for the OData client.
+    /// </summary>
+    public ODataBatchSettings Batch { get; set; } = new();
 }

--- a/IntegratoR.OData/Domain/Settings/ODataSettingsValidator.cs
+++ b/IntegratoR.OData/Domain/Settings/ODataSettingsValidator.cs
@@ -87,6 +87,14 @@ public sealed class ODataSettingsValidator : IValidateOptions<ODataSettings>
                 break;
         }
 
+        // Batch chunk size must stay within D365's documented ceiling of 5000 operations per $batch.
+        if (options.Batch.MaxOperationsPerChunk is < 1 or > 5000)
+        {
+            failures.Add(
+                $"ODataSettings.Batch.MaxOperationsPerChunk must be between 1 and 5000 (D365's documented maximum " +
+                $"operations per $batch). The configured value was {options.Batch.MaxOperationsPerChunk}.");
+        }
+
         return failures.Count > 0
             ? ValidateOptionsResult.Fail(failures)
             : ValidateOptionsResult.Success;

--- a/tests/IntegratoR.Abstractions.Tests/Common/Batch/BatchOutcomeTests.cs
+++ b/tests/IntegratoR.Abstractions.Tests/Common/Batch/BatchOutcomeTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using IntegratoR.Abstractions.Common.Batch;
+using Xunit;
+
+namespace IntegratoR.Abstractions.Tests.Common.Batch;
+
+/// <summary>
+/// Tests the computed aggregation on <see cref="BatchOutcome"/> (totals and the failure projection).
+/// </summary>
+public class BatchOutcomeTests
+{
+    private static BatchItemResult Item(int index, bool ok) => new()
+    {
+        Index = index,
+        ChunkIndex = 0,
+        IsSuccess = ok,
+        StatusCode = ok ? 204 : 400,
+        ErrorCode = ok ? null : "Entity.Failed",
+        ErrorMessage = ok ? null : "boom",
+    };
+
+    [Fact]
+    public void Outcome_WithMixedItems_ComputesTotalsAndFailures()
+    {
+        var outcome = new BatchOutcome
+        {
+            Mode = BatchFailureMode.ContinueOnError,
+            ChunkCount = 1,
+            Items = [Item(0, true), Item(1, false), Item(2, true), Item(3, false)],
+        };
+
+        outcome.Total.Should().Be(4);
+        outcome.Succeeded.Should().Be(2);
+        outcome.Failed.Should().Be(2);
+        outcome.AllSucceeded.Should().BeFalse();
+        outcome.Failures.Select(f => f.Index).Should().Equal(1, 3);
+    }
+
+    [Fact]
+    public void Outcome_WithNoFailures_ReportsAllSucceeded()
+    {
+        var outcome = new BatchOutcome
+        {
+            Mode = BatchFailureMode.Atomic,
+            ChunkCount = 1,
+            Items = [Item(0, true), Item(1, true)],
+        };
+
+        outcome.AllSucceeded.Should().BeTrue();
+        outcome.Failed.Should().Be(0);
+        outcome.Failures.Should().BeEmpty();
+    }
+}

--- a/tests/IntegratoR.Abstractions.Tests/Common/Results/BatchIntegrationErrorTests.cs
+++ b/tests/IntegratoR.Abstractions.Tests/Common/Results/BatchIntegrationErrorTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using FluentResults;
+using IntegratoR.Abstractions.Common.Batch;
+using IntegratoR.Abstractions.Common.Results;
+using Xunit;
+
+namespace IntegratoR.Abstractions.Tests.Common.Results;
+
+/// <summary>
+/// Tests that <see cref="BatchIntegrationError"/> carries the <see cref="BatchOutcome"/> and remains
+/// retrievable from a failed <see cref="Result{T}"/> via <c>GetError()</c> — the mechanism that keeps
+/// the per-item failure list available when a batch fails.
+/// </summary>
+public class BatchIntegrationErrorTests
+{
+    private static BatchOutcome FailingOutcome() => new()
+    {
+        Mode = BatchFailureMode.Atomic,
+        ChunkCount = 1,
+        Items =
+        [
+            new BatchItemResult { Index = 0, ChunkIndex = 0, IsSuccess = false, StatusCode = 403, ErrorCode = "Entity.Denied", ErrorMessage = "no" },
+        ],
+    };
+
+    [Fact]
+    public void BatchIntegrationError_CarriesOutcome_AndIsAnIntegrationError()
+    {
+        BatchOutcome outcome = FailingOutcome();
+
+        var error = new BatchIntegrationError("Entity.BatchFailed", "1 of 1 operations failed", outcome);
+
+        error.Should().BeAssignableTo<IntegrationError>();
+        error.Code.Should().Be("Entity.BatchFailed");
+        error.Type.Should().Be(ErrorType.Failure);
+        error.Message.Should().Be("1 of 1 operations failed");
+        error.Outcome.Should().BeSameAs(outcome);
+    }
+
+    [Fact]
+    public void FailedResult_ExposesOutcome_ViaGetError()
+    {
+        BatchOutcome outcome = FailingOutcome();
+        Result<BatchOutcome> result = Result.Fail<BatchOutcome>(
+            new BatchIntegrationError("Entity.BatchFailed", "1 of 1 operations failed", outcome));
+
+        result.IsFailed.Should().BeTrue();
+        IntegrationError? error = result.GetError();
+        error.Should().BeOfType<BatchIntegrationError>();
+        ((BatchIntegrationError)error!).Outcome.Failures.Should().ContainSingle(f => f.ErrorCode == "Entity.Denied");
+    }
+}

--- a/tests/IntegratoR.OData.Tests/Domain/Settings/ODataBatchSettingsValidationTests.cs
+++ b/tests/IntegratoR.OData.Tests/Domain/Settings/ODataBatchSettingsValidationTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using IntegratoR.OData.Domain.Settings;
+using Xunit;
+
+namespace IntegratoR.OData.Tests.Domain.Settings;
+
+/// <summary>
+/// Tests the <see cref="ODataSettingsValidator"/> bound on <c>Batch.MaxOperationsPerChunk</c>
+/// (1..5000, D365's documented maximum operations per <c>$batch</c>).
+/// </summary>
+public class ODataBatchSettingsValidationTests
+{
+    private readonly ODataSettingsValidator _sut = new();
+
+    private static ODataSettings ValidBase() => new()
+    {
+        Url = "https://test.operations.dynamics.com/data",
+        Authentication = new ODataAuthenticationSettings
+        {
+            Mode = AuthenticationMode.OAuth,
+            OAuth = new ODataOAuthSettings { ClientId = "c", ClientSecret = "s", TenantId = "t", Resource = "r" },
+        },
+    };
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(5001)]
+    public void Validate_MaxOperationsPerChunkOutOfRange_Fails(int value)
+    {
+        ODataSettings settings = ValidBase();
+        settings.Batch.MaxOperationsPerChunk = value;
+
+        var result = _sut.Validate(null, settings);
+
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("MaxOperationsPerChunk");
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(150)]
+    [InlineData(5000)]
+    public void Validate_MaxOperationsPerChunkInRange_Passes(int value)
+    {
+        ODataSettings settings = ValidBase();
+        settings.Batch.MaxOperationsPerChunk = value;
+
+        var result = _sut.Validate(null, settings);
+
+        result.Succeeded.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

PR-1 of the configurable OData `$batch` redesign (target **v3.0.0**). **Additive only** — new public types + settings; no behaviour is wired yet, so this is non-breaking on its own.

## What's added

- **`IntegratoR.Abstractions.Common.Batch`**: `BatchFailureMode` (`Atomic` / `ContinueOnError`), `BatchItemResult` (index, chunk, status, composite **key**, D365 error — for import analysis), `BatchOutcome` (totals + `Failures`), `BatchOptions` (per-call override).
- **`IntegratoR.Abstractions.Common.Results.BatchIntegrationError`** — an `IntegrationError` that carries the `BatchOutcome`, so a failed `Result<BatchOutcome>` surfaces the per-item failure list via `result.GetError()`.
- **`ODataSettings.Batch`** (`ODataBatchSettings`): `FailureMode` (default `Atomic`), `MaxOperationsPerChunk` (default **150**), `StopOnFirstFailedChunk`, `UseServerContinueOnError`; validator bound **1..5000** (D365's documented `$batch` ceiling).

## Grounding

Design is fact-founded: D365 documents changeset atomicity and a 5,000-op `$batch` cap; `continue-on-error` is undocumented for F&O (hence `UseServerContinueOnError` defaults off, to be live-verified). Full plan tracked internally.

## Tests

Abstractions.Tests **121/121**, OData.Tests **213/213**, build 0 warnings. New tests cover the computed `BatchOutcome` aggregation, the `BatchIntegrationError` → `GetError()` retrieval mechanism, and the `MaxOperationsPerChunk` bound.

## Risk

Additive public API (MINOR). The breaking switch to `Result<BatchOutcome>` (MAJOR) lands in a later PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)