### PR TITLE
feat(batch): multipart $batch emitter + response parser (PR-2)

### DIFF
--- a/IntegratoR.OData/Common/Batch/BatchWriteOperation.cs
+++ b/IntegratoR.OData/Common/Batch/BatchWriteOperation.cs
@@ -1,0 +1,11 @@
+namespace IntegratoR.OData.Common.Batch;
+
+/// <summary>
+/// One write request inside an OData <c>$batch</c>: the HTTP method, the entity-set-relative URL, an
+/// optional JSON body, and the <c>Content-ID</c> used to correlate the request with its response.
+/// </summary>
+/// <param name="ContentId">The 1-based Content-ID that correlates this request with its response part.</param>
+/// <param name="Method">The HTTP method (POST for create, PATCH for update, DELETE for delete).</param>
+/// <param name="RelativeUrl">The entity-set-relative URL, e.g. <c>LedgerJournalHeaders(dataAreaId='USMF',JournalBatchNumber='B1')</c> or <c>LedgerJournalHeaders</c> for a create.</param>
+/// <param name="JsonBody">The serialised JSON payload, or <c>null</c> for a body-less request such as DELETE.</param>
+internal sealed record BatchWriteOperation(int ContentId, HttpMethod Method, string RelativeUrl, string? JsonBody = null);

--- a/IntegratoR.OData/Common/Batch/ODataBatchRequestBuilder.cs
+++ b/IntegratoR.OData/Common/Batch/ODataBatchRequestBuilder.cs
@@ -1,0 +1,97 @@
+using System.Text;
+
+namespace IntegratoR.OData.Common.Batch;
+
+/// <summary>
+/// Emits an OData v4 <c>multipart/mixed</c> <c>$batch</c> request body for a set of write operations,
+/// either as a single atomic changeset or as independent top-level requests.
+/// </summary>
+/// <remarks>
+/// D365 F&amp;O accepts only the multipart batch format (not the OData 4.01 JSON batch format), so the
+/// body is hand-assembled to the OASIS OData v4.01 Part 1 §11.7.7 shape: CRLF line endings, a
+/// client-chosen batch boundary, per-part <c>application/http</c> / <c>Content-Transfer-Encoding:
+/// binary</c> / <c>Content-ID</c> headers, and an embedded <c>METHOD url HTTP/1.1</c> request line.
+/// </remarks>
+internal static class ODataBatchRequestBuilder
+{
+    private const string Crlf = "\r\n";
+
+    /// <summary>
+    /// A built batch body together with the <c>Content-Type</c> header value (carrying the boundary)
+    /// that must be set on the outer <c>$batch</c> request.
+    /// </summary>
+    internal sealed record BuiltBatchRequest(string ContentType, string Body);
+
+    /// <summary>
+    /// Generates a boundary token that cannot collide with typical body content.
+    /// </summary>
+    internal static string NewBoundary(string prefix) => $"{prefix}_{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// Builds the batch body and its Content-Type header.
+    /// </summary>
+    /// <param name="operations">The write operations, in the order they should be applied.</param>
+    /// <param name="atomic">When <c>true</c>, wraps all operations in a single changeset (all-or-nothing); when <c>false</c>, emits them as independent top-level requests.</param>
+    /// <param name="batchBoundary">The outer batch boundary token.</param>
+    /// <param name="changesetBoundary">The changeset boundary token, used only when <paramref name="atomic"/> is <c>true</c>.</param>
+    internal static BuiltBatchRequest Build(
+        IReadOnlyList<BatchWriteOperation> operations,
+        bool atomic,
+        string batchBoundary,
+        string changesetBoundary)
+    {
+        var sb = new StringBuilder();
+
+        if (atomic)
+        {
+            sb.Append("--").Append(batchBoundary).Append(Crlf);
+            sb.Append("Content-Type: multipart/mixed; boundary=").Append(changesetBoundary).Append(Crlf);
+            sb.Append(Crlf);
+
+            foreach (BatchWriteOperation operation in operations)
+            {
+                sb.Append("--").Append(changesetBoundary).Append(Crlf);
+                AppendOperation(sb, operation);
+            }
+
+            sb.Append("--").Append(changesetBoundary).Append("--").Append(Crlf);
+            sb.Append("--").Append(batchBoundary).Append("--").Append(Crlf);
+        }
+        else
+        {
+            foreach (BatchWriteOperation operation in operations)
+            {
+                sb.Append("--").Append(batchBoundary).Append(Crlf);
+                AppendOperation(sb, operation);
+            }
+
+            sb.Append("--").Append(batchBoundary).Append("--").Append(Crlf);
+        }
+
+        return new BuiltBatchRequest($"multipart/mixed; boundary={batchBoundary}", sb.ToString());
+    }
+
+    private static void AppendOperation(StringBuilder sb, BatchWriteOperation operation)
+    {
+        // MIME part headers.
+        sb.Append("Content-Type: application/http").Append(Crlf);
+        sb.Append("Content-Transfer-Encoding: binary").Append(Crlf);
+        sb.Append("Content-ID: ").Append(operation.ContentId).Append(Crlf);
+        sb.Append(Crlf);
+
+        // Embedded HTTP request: request line, headers, blank line, optional body.
+        sb.Append(operation.Method.Method).Append(' ').Append(operation.RelativeUrl).Append(" HTTP/1.1").Append(Crlf);
+        sb.Append("OData-Version: 4.0").Append(Crlf);
+        if (operation.JsonBody is not null)
+        {
+            sb.Append("Content-Type: application/json").Append(Crlf);
+        }
+
+        sb.Append(Crlf);
+
+        if (operation.JsonBody is not null)
+        {
+            sb.Append(operation.JsonBody).Append(Crlf);
+        }
+    }
+}

--- a/IntegratoR.OData/Common/Batch/ODataBatchResponseParser.cs
+++ b/IntegratoR.OData/Common/Batch/ODataBatchResponseParser.cs
@@ -1,0 +1,127 @@
+namespace IntegratoR.OData.Common.Batch;
+
+/// <summary>
+/// Parses an OData v4 <c>multipart/mixed</c> <c>$batch</c> response into a flat list of per-operation
+/// sub-responses, recursing into changeset parts and correlating by <c>Content-ID</c> where present.
+/// </summary>
+/// <remarks>
+/// The server chooses its own response boundary (taken from the response <c>Content-Type</c>, not the
+/// request boundary). A changeset that failed atomically collapses to a single error sub-response;
+/// callers map that failure onto every operation the changeset contained. Correlation: top-level
+/// responses are positional (document order); changeset responses carry their request's <c>Content-ID</c>.
+/// </remarks>
+internal static class ODataBatchResponseParser
+{
+    /// <summary>
+    /// One embedded HTTP response from a batch: its <c>Content-ID</c> (when inside a changeset), the
+    /// HTTP status code, and the response body (if any).
+    /// </summary>
+    internal sealed record BatchSubResponse(int? ContentId, int StatusCode, string? Body);
+
+    /// <summary>
+    /// Parses a batch response body using the boundary from its <c>Content-Type</c> header.
+    /// </summary>
+    /// <exception cref="FormatException">Thrown when the Content-Type carries no boundary parameter.</exception>
+    internal static IReadOnlyList<BatchSubResponse> Parse(string responseContentType, string responseBody)
+    {
+        string boundary = ExtractBoundary(responseContentType)
+            ?? throw new FormatException(
+                $"Batch response Content-Type did not contain a boundary: '{responseContentType}'.");
+
+        var results = new List<BatchSubResponse>();
+        ParseInto(boundary, responseBody, results);
+        return results;
+    }
+
+    private static void ParseInto(string boundary, string content, List<BatchSubResponse> results)
+    {
+        string delimiter = "--" + boundary;
+        string[] segments = content.Split(delimiter);
+
+        foreach (string segment in segments)
+        {
+            string part = segment.Trim('\r', '\n');
+            if (part.Length == 0 || part == "--")
+            {
+                // Preamble, inter-part whitespace, or the closing "--boundary--" tail.
+                continue;
+            }
+
+            int headerSep = part.IndexOf("\r\n\r\n", StringComparison.Ordinal);
+            string partHeaders = headerSep >= 0 ? part[..headerSep] : part;
+            string partContent = headerSep >= 0 ? part[(headerSep + 4)..] : string.Empty;
+
+            string? partContentType = GetHeader(partHeaders, "Content-Type");
+
+            if (partContentType is not null &&
+                partContentType.StartsWith("multipart/mixed", StringComparison.OrdinalIgnoreCase))
+            {
+                string? nested = ExtractBoundary(partContentType);
+                if (nested is not null)
+                {
+                    ParseInto(nested, partContent, results);
+                }
+
+                continue;
+            }
+
+            int? contentId = TryParseInt(GetHeader(partHeaders, "Content-ID"));
+            (int status, string? body) = ParseEmbeddedHttp(partContent);
+            results.Add(new BatchSubResponse(contentId, status, body));
+        }
+    }
+
+    private static (int Status, string? Body) ParseEmbeddedHttp(string embedded)
+    {
+        string trimmed = embedded.TrimStart('\r', '\n');
+
+        int firstLineEnd = trimmed.IndexOf("\r\n", StringComparison.Ordinal);
+        string statusLine = firstLineEnd >= 0 ? trimmed[..firstLineEnd] : trimmed;
+        int status = ParseStatusCode(statusLine);
+
+        int bodySep = trimmed.IndexOf("\r\n\r\n", StringComparison.Ordinal);
+        string? body = bodySep >= 0 ? trimmed[(bodySep + 4)..].Trim('\r', '\n') : null;
+        return (status, string.IsNullOrEmpty(body) ? null : body);
+    }
+
+    private static int ParseStatusCode(string statusLine)
+    {
+        // "HTTP/1.1 204 No Content" -> 204
+        string[] tokens = statusLine.Split(' ', 3);
+        return tokens.Length >= 2 && int.TryParse(tokens[1], out int code) ? code : 0;
+    }
+
+    private static string? GetHeader(string headerBlock, string name)
+    {
+        foreach (string line in headerBlock.Split("\r\n"))
+        {
+            int colon = line.IndexOf(':');
+            if (colon > 0 && line[..colon].Trim().Equals(name, StringComparison.OrdinalIgnoreCase))
+            {
+                return line[(colon + 1)..].Trim();
+            }
+        }
+
+        return null;
+    }
+
+    private static string? ExtractBoundary(string contentType)
+    {
+        int idx = contentType.IndexOf("boundary=", StringComparison.OrdinalIgnoreCase);
+        if (idx < 0)
+        {
+            return null;
+        }
+
+        string value = contentType[(idx + "boundary=".Length)..].Trim();
+        int semicolon = value.IndexOf(';');
+        if (semicolon >= 0)
+        {
+            value = value[..semicolon];
+        }
+
+        return value.Trim().Trim('"');
+    }
+
+    private static int? TryParseInt(string? raw) => int.TryParse(raw, out int value) ? value : null;
+}

--- a/tests/IntegratoR.OData.Tests/Common/Batch/ODataBatchWireTests.cs
+++ b/tests/IntegratoR.OData.Tests/Common/Batch/ODataBatchWireTests.cs
@@ -1,0 +1,135 @@
+using FluentAssertions;
+using IntegratoR.OData.Common.Batch;
+using Xunit;
+
+namespace IntegratoR.OData.Tests.Common.Batch;
+
+/// <summary>
+/// Tests the hand-rolled multipart <c>$batch</c> emitter and response parser against the OData v4.01
+/// multipart shape (OASIS Part 1 §11.7.7).
+/// </summary>
+public class ODataBatchWireTests
+{
+    private static readonly BatchWriteOperation Patch = new(
+        1, HttpMethod.Patch, "LedgerJournalHeaders(dataAreaId='USMF',JournalBatchNumber='B1')", "{\"Description\":\"x\"}");
+
+    private static readonly BatchWriteOperation Delete = new(
+        2, HttpMethod.Delete, "LedgerJournalHeaders(dataAreaId='USMF',JournalBatchNumber='B2')");
+
+    /// <summary>Joins lines with CRLF and appends a trailing CRLF, matching the wire format.</summary>
+    private static string Wire(params string[] lines) => string.Join("\r\n", lines) + "\r\n";
+
+    [Fact]
+    public void Build_Atomic_WrapsOperationsInASingleChangeset()
+    {
+        ODataBatchRequestBuilder.BuiltBatchRequest built =
+            ODataBatchRequestBuilder.Build([Patch, Delete], atomic: true, "batch1", "cs1");
+
+        built.ContentType.Should().Be("multipart/mixed; boundary=batch1");
+        built.Body.Should().Contain("--batch1\r\nContent-Type: multipart/mixed; boundary=cs1");
+        built.Body.Should().Contain("Content-ID: 1").And.Contain("Content-ID: 2");
+        built.Body.Should().Contain("PATCH LedgerJournalHeaders(dataAreaId='USMF',JournalBatchNumber='B1') HTTP/1.1");
+        built.Body.Should().Contain("Content-Type: application/json\r\n\r\n{\"Description\":\"x\"}");
+        built.Body.Should().Contain("DELETE LedgerJournalHeaders(dataAreaId='USMF',JournalBatchNumber='B2') HTTP/1.1");
+        built.Body.Should().EndWith("--cs1--\r\n--batch1--\r\n");
+    }
+
+    [Fact]
+    public void Build_Individual_EmitsTopLevelParts_WithNoChangeset()
+    {
+        ODataBatchRequestBuilder.BuiltBatchRequest built =
+            ODataBatchRequestBuilder.Build([Patch, Delete], atomic: false, "batch1", "cs1");
+
+        built.Body.Should().NotContain("multipart/mixed; boundary=cs1");
+        built.Body.Should().Contain("--batch1\r\nContent-Type: application/http");
+        built.Body.Should().EndWith("--batch1--\r\n");
+    }
+
+    [Fact]
+    public void Parse_IndividualResponses_ReturnsPerOperationStatusesInOrder()
+    {
+        string body = Wire(
+            "--resp1",
+            "Content-Type: application/http",
+            "",
+            "HTTP/1.1 204 No Content",
+            "",
+            "--resp1",
+            "Content-Type: application/http",
+            "",
+            "HTTP/1.1 400 Bad Request",
+            "Content-Type: application/json",
+            "",
+            "{\"error\":{\"code\":\"X\",\"message\":\"bad\"}}",
+            "--resp1--");
+
+        IReadOnlyList<ODataBatchResponseParser.BatchSubResponse> results =
+            ODataBatchResponseParser.Parse("multipart/mixed; boundary=resp1", body);
+
+        results.Select(r => r.StatusCode).Should().Equal(204, 400);
+        results[0].Body.Should().BeNull();
+        results[1].Body.Should().Contain("\"code\":\"X\"");
+    }
+
+    [Fact]
+    public void Parse_ChangesetSuccess_CorrelatesByContentId()
+    {
+        string body = Wire(
+            "--b1",
+            "Content-Type: multipart/mixed; boundary=cs1",
+            "",
+            "--cs1",
+            "Content-Type: application/http",
+            "Content-ID: 1",
+            "",
+            "HTTP/1.1 201 Created",
+            "",
+            "--cs1",
+            "Content-Type: application/http",
+            "Content-ID: 2",
+            "",
+            "HTTP/1.1 204 No Content",
+            "",
+            "--cs1--",
+            "--b1--");
+
+        IReadOnlyList<ODataBatchResponseParser.BatchSubResponse> results =
+            ODataBatchResponseParser.Parse("multipart/mixed; boundary=b1", body);
+
+        results.Select(r => r.ContentId).Should().Equal(1, 2);
+        results.Select(r => r.StatusCode).Should().Equal(201, 204);
+    }
+
+    [Fact]
+    public void Parse_ChangesetCollapsedError_ReturnsSingleFailure()
+    {
+        string body = Wire(
+            "--b1",
+            "Content-Type: multipart/mixed; boundary=cs1",
+            "",
+            "--cs1",
+            "Content-Type: application/http",
+            "",
+            "HTTP/1.1 400 Bad Request",
+            "Content-Type: application/json",
+            "",
+            "{\"error\":{\"code\":\"Y\",\"message\":\"nope\"}}",
+            "--cs1--",
+            "--b1--");
+
+        IReadOnlyList<ODataBatchResponseParser.BatchSubResponse> results =
+            ODataBatchResponseParser.Parse("multipart/mixed; boundary=b1", body);
+
+        results.Should().ContainSingle();
+        results[0].StatusCode.Should().Be(400);
+        results[0].Body.Should().Contain("\"code\":\"Y\"");
+    }
+
+    [Fact]
+    public void Parse_MissingBoundary_Throws()
+    {
+        Action act = () => ODataBatchResponseParser.Parse("application/json", "irrelevant");
+
+        act.Should().Throw<FormatException>();
+    }
+}


### PR DESCRIPTION
## Summary

PR-2 of the OData `$batch` redesign: the `multipart/mixed` **wire layer** (emitter + parser), unit-tested in isolation. **Internal + additive** — no public API or behaviour change. These building blocks are consumed by the breaking PR-3 (adapter/service wiring + chunking + `Result<BatchOutcome>`), which is stacked on this branch.

## What's added (`IntegratoR.OData.Common.Batch`, internal)

- **`ODataBatchRequestBuilder`** — emits the OData v4.01 `multipart/mixed` `$batch` body (OASIS Part 1 §11.7.7): CRLF, client boundary, per-part `application/http` + `Content-Transfer-Encoding: binary` + `Content-ID`, embedded `METHOD url HTTP/1.1`. Atomic mode → one changeset; individual mode → top-level parts.
- **`ODataBatchResponseParser`** — parses the multipart response into per-op sub-responses, recursing changesets (correlate by `Content-ID`), handling the changeset-collapsed-error case.
- **`BatchWriteOperation`** — one write op (method/url/body/Content-ID).

## Tests

6 wire tests (emit atomic/individual; parse individual / changeset-success / changeset-collapsed-error / missing-boundary). Full batch suite **22/22** green.

## Notes

- These internal types are **not yet called by production code** — the adapter/service wiring lands in the stacked PR-3. Reviewed as a self-contained, tested wire-format module.
- D365 byte-level `$batch` acceptance is pinned by a live JFI run in PR-5 (F&O `continue-on-error` is undocumented and stays off until verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)